### PR TITLE
Fix world age issue in BNG parameter parsing

### DIFF
--- a/src/parsing_routines_bngnetworkfiles.jl
+++ b/src/parsing_routines_bngnetworkfiles.jl
@@ -192,10 +192,11 @@ function parse_groups(ft::BNGNetwork, lines, idx, shortsymstosyms, idstoshortsym
     obseqs, namestosyms, idx
 end
 
-function exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs)
+function exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs, ps)
     pmap = Dict()
+    psym_to_pvar = Dict(nameof(p) => p for p in ps)
     for (psym, pid) in ptoids
-        pvar = getproperty(opmod, psym)
+        pvar = psym_to_pvar[psym]
         parsedval = pvals[pid]
         if (parsedval isa Expr) || (parsedval isa Symbol)
             pval = Base.eval(opmod, :($parsedval))
@@ -311,7 +312,7 @@ function loadrxnetwork(ft::BNGNetwork, rxfilename; name = gensym(:ReactionSystem
     close(file)
 
     # setup default values / expressions for params and initial conditions
-    defmap, pmap, u0map = exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs)
+    defmap, pmap, u0map = exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs, ps)
 
     # build the model
     rn = ReactionSystem(rxs, t, specs, ps; name = name, observed = obseqs,


### PR DESCRIPTION
## Summary

Fixed `UndefVarError: kp1 not defined` in BNG Birth-Death Test by resolving a world age issue when accessing parameter variables from a dynamically created module.

## Changes Made

- Modified `exprs_to_defs()` function signature to accept parameters as a direct argument
- Replaced `getproperty(opmod, psym)` with direct parameter lookup using a mapping dictionary
- Updated the function call in `loadrxnetwork()` to pass the parameters argument

## Root Cause

The error occurred because the code tried to access parameter variables from a dynamically created module using `getproperty(opmod, psym)`, but there was a world age mismatch preventing access to the newly defined variables in the module.

## Solution

Instead of trying to retrieve parameters from the module, we now pass the already-created parameter variables directly to the function and use a simple dictionary lookup: `psym_to_pvar = Dict(nameof(p) => p for p in ps)`.

## Test Results

- ✅ BNG Birth-Death Test now passes
- ✅ All existing tests continue to pass
- ✅ Code formatted with JuliaFormatter

## Test Plan

- [x] Run specific failing test (`test_nullrxs_odes.jl`)
- [x] Run full test suite to ensure no regressions
- [x] Format code with JuliaFormatter

🤖 Generated with [Claude Code](https://claude.ai/code)