### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-format_markdown = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,26 +8,38 @@ cp(joinpath(docpath, "Project.toml"), joinpath(assetpath, "Project.toml"), force
 
 include("pages.jl")
 
-mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
-    :tex => Dict("inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
-        "packages" => [
-            "base",
-            "ams",
-            "autoload",
-            "mathtools",
-            "require"
-        ])))
+mathengine = MathJax3(
+    Dict(
+        :loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
+        :tex => Dict(
+            "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+            "packages" => [
+                "base",
+                "ams",
+                "autoload",
+                "mathtools",
+                "require",
+            ]
+        )
+    )
+)
 
-makedocs(sitename = "ReactionNetworkImporters.jl",
+makedocs(
+    sitename = "ReactionNetworkImporters.jl",
     authors = "Samuel Isaacson",
-    format = Documenter.HTML(; analytics = "UA-90474609-3",
+    format = Documenter.HTML(;
+        analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],
         mathengine,
         prettyurls = (get(ENV, "CI", nothing) == "true"),
-        canonical = "https://docs.sciml.ai/ReactionNetworkImporters/stable/"),
+        canonical = "https://docs.sciml.ai/ReactionNetworkImporters/stable/"
+    ),
     modules = [ReactionNetworkImporters],
     checkdocs = :exports, warnonly = [:missing_docs],
-    clean = true, doctest = false, pages = pages)
+    clean = true, doctest = false, pages = pages
+)
 
-deploydocs(repo = "github.com/SciML/ReactionNetworkImporters.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/ReactionNetworkImporters.jl.git";
+    push_preview = true
+)

--- a/examples/bcrssa_bench.jl
+++ b/examples/bcrssa_bench.jl
@@ -27,8 +27,10 @@ rn = prn.rn
 # post equilibration solve
 tf = 20000.0
 jsys = convert(JumpSystem, rn)
-u0 = convert.(Int,
-    ModelingToolkit.varmap_to_vars(ModelingToolkit.defaults(jsys), states(jsys)))
+u0 = convert.(
+    Int,
+    ModelingToolkit.varmap_to_vars(ModelingToolkit.defaults(jsys), states(jsys))
+)
 dprob = DiscreteProblem(jsys, u0, (0.0, tf), [])
 @assert eltype(dprob.u0) <: Int
 jprob = JumpProblem(jsys, dprob, RSSACR(), save_positions = (false, false))

--- a/examples/not_updated_yet/test_network.jl
+++ b/examples/not_updated_yet/test_network.jl
@@ -10,7 +10,7 @@ const to = TimerOutput()
 
 # parameters
 method = RSSA()
-nsteps = 1e5                  # time to simulate to
+nsteps = 1.0e5                  # time to simulate to
 networkname = "tester"
 tf = 10.0
 #speciesf = path to species initial population file
@@ -18,15 +18,19 @@ tf = 10.0
 
 # get the RSSA reaction network
 reset_timer!(to)
-@timeit to "netgen" prn=loadrxnetwork(RSSANetwork(), networkname, speciesf, rxsf;
-    printrxs = false)
+@timeit to "netgen" prn = loadrxnetwork(
+    RSSANetwork(), networkname, speciesf, rxsf;
+    printrxs = false
+)
 rn = prn.rn
 initialpop = prn.u0
 println("network parsed")
 
 # get the BioNetGen reaction network
-@timeit to "bionetgen" prnbng=loadrxnetwork(BNGNetwork(), string(networkname, "bng"),
-    bngfname)
+@timeit to "bionetgen" prnbng = loadrxnetwork(
+    BNGNetwork(), string(networkname, "bng"),
+    bngfname
+)
 rnbng = prnbng.rn;
 u0 = prnbng.u0;
 p = prnbng.p;
@@ -38,17 +42,17 @@ println(typeof(u0))
 # one simulation
 @timeit to "addjumps" addjumps!(rn, build_regular_jumps = false, minimal_jumps = true)
 println("added jumps")
-@timeit to "dprob" rprob=DiscreteProblem(rn, u0, (0.0, tf))
-@timeit to "jprob" rjprob=JumpProblem(rprob, method, rn; save_positions = (false, false))
-@timeit to "solve" rsol=solve(rjprob, SSAStepper(), saveat = tf / 1000)
+@timeit to "dprob" rprob = DiscreteProblem(rn, u0, (0.0, tf))
+@timeit to "jprob" rjprob = JumpProblem(rprob, method, rn; save_positions = (false, false))
+@timeit to "solve" rsol = solve(rjprob, SSAStepper(), saveat = tf / 1000)
 show(to)
 
 # bng file
 reset_timer!(to)
 @timeit to "addjumps" addjumps!(rnbng, build_regular_jumps = false, minimal_jumps = true)
-@timeit to "dprob" bprob=DiscreteProblem(rnbng, u0, (0.0, tf), p)
-@timeit to "jprob" bjprob=JumpProblem(bprob, method, rnbng; save_positions = (false, false))
-@timeit to "solve" bsol=solve(bjprob, SSAStepper(), saveat = tf / 1000)
+@timeit to "dprob" bprob = DiscreteProblem(rnbng, u0, (0.0, tf), p)
+@timeit to "jprob" bjprob = JumpProblem(bprob, method, rnbng; save_positions = (false, false))
+@timeit to "solve" bsol = solve(bjprob, SSAStepper(), saveat = tf / 1000)
 show(to)
 
 # plot

--- a/examples/not_updated_yet/test_odes.jl
+++ b/examples/not_updated_yet/test_odes.jl
@@ -14,13 +14,15 @@ const to = TimerOutput()
 reset_timer!(to)
 
 # get the reaction network
-@timeit to "netgen" prnbng=loadrxnetwork(BNGNetwork(), string(networkname, "bng"), fname);
+@timeit to "netgen" prnbng = loadrxnetwork(BNGNetwork(), string(networkname, "bng"), fname);
 rn = prnbng.rn;
 u0 = prnbng.u0;
 p = prnbng.p;
-@timeit to "addodes" addodes!(rn; build_jac = build_jac, sparse_jac = sparse_jac,
-    build_symfuncs = false, build_paramjac = false)
-@timeit to "ODEProb" oprob=ODEProblem(rn, u0, (0.0, tf), p)
+@timeit to "addodes" addodes!(
+    rn; build_jac = build_jac, sparse_jac = sparse_jac,
+    build_symfuncs = false, build_paramjac = false
+)
+@timeit to "ODEProb" oprob = ODEProblem(rn, u0, (0.0, tf), p)
 u = copy(u0);
 du = similar(u);
 @timeit to "f1" rn.f(du, u, p, 0.0)
@@ -33,38 +35,46 @@ end
 show(to)
 println()
 
-# note solvers run faster the second time 
+# note solvers run faster the second time
 
 # Rodas4
 #reset_timer!(to); @timeit to "Rodas4" begin sol = solve(oprob,Rodas4(autodiff=false),dense=false,calck=false); end; show(to)
 #reset_timer!(to); @timeit to "Rodas4" begin sol = solve(oprob,Rodas4(autodiff=false),dense=false,calck=false); end; show(to)
 #reset_timer!(to); @timeit to "Rodas4" begin sol = solve(oprob,Rodas4(autodiff=false),dense=false); end;
 
-# similarly CVODE_BDF with gmres 
+# similarly CVODE_BDF with gmres
 dense = true
 calck = true
-# @timeit to "CVODE_BDF-GMRES-1" begin sol = solve(oprob,CVODE_BDF(linear_solver=:GMRES),dense=dense, abstol=1e-8, reltol=1e-8); end; 
-# @timeit to "CVODE_BDF-GMRES-2" begin sol = solve(oprob,CVODE_BDF(linear_solver=:GMRES),dense=dense, abstol=1e-8, reltol=1e-8); end; 
+# @timeit to "CVODE_BDF-GMRES-1" begin sol = solve(oprob,CVODE_BDF(linear_solver=:GMRES),dense=dense, abstol=1e-8, reltol=1e-8); end;
+# @timeit to "CVODE_BDF-GMRES-2" begin sol = solve(oprob,CVODE_BDF(linear_solver=:GMRES),dense=dense, abstol=1e-8, reltol=1e-8); end;
 
-# CVODE_BDF with LU 
+# CVODE_BDF with LU
 @timeit to "CVODE_BDF-1" begin
-    sol = solve(oprob, CVODE_BDF(), dense = dense, abstol = 1e-8,
-        reltol = 1e-8)
+    sol = solve(
+        oprob, CVODE_BDF(), dense = dense, abstol = 1.0e-8,
+        reltol = 1.0e-8
+    )
 end;
 show(to);
 @timeit to "CVODE_BDF-2" begin
-    sol = solve(oprob, CVODE_BDF(), dense = dense, abstol = 1e-8,
-        reltol = 1e-8)
+    sol = solve(
+        oprob, CVODE_BDF(), dense = dense, abstol = 1.0e-8,
+        reltol = 1.0e-8
+    )
 end;
 show(to);
 @timeit to "KenCarp4-1" begin
-    sol = solve(oprob, KenCarp4(autodiff = false), dense = dense,
-        calck = calck, abstol = 1e-8, reltol = 1e-8)
+    sol = solve(
+        oprob, KenCarp4(autodiff = false), dense = dense,
+        calck = calck, abstol = 1.0e-8, reltol = 1.0e-8
+    )
 end;
 show(to);
 @timeit to "KenCarp4-2" begin
-    sol = solve(oprob, KenCarp4(autodiff = false), dense = dense,
-        calck = calck, abstol = 1e-8, reltol = 1e-8)
+    sol = solve(
+        oprob, KenCarp4(autodiff = false), dense = dense,
+        calck = calck, abstol = 1.0e-8, reltol = 1.0e-8
+    )
 end;
 
 show(to)

--- a/examples/not_updated_yet/test_odes_rssa.jl
+++ b/examples/not_updated_yet/test_odes_rssa.jl
@@ -9,7 +9,7 @@ using TimerOutputs
 networkname = "tester"
 tf = 10.0
 
-# input files, specify path 
+# input files, specify path
 datadir = joinpath(@__DIR__, "../data/repressilator")
 fname = joinpath(datadir, "Repressilator.net")
 
@@ -17,17 +17,21 @@ const to = TimerOutput()
 reset_timer!(to)
 
 # get the reaction network
-@timeit to "netgen" prn=loadrxnetwork(RSSAFile(), networkname, speciesf, rxsf;
-    printrxs = false)
+@timeit to "netgen" prn = loadrxnetwork(
+    RSSAFile(), networkname, speciesf, rxsf;
+    printrxs = false
+)
 rn = prn.rn;
 initialpop = prn.u0;
-@timeit to "addodes" addodes!(rn; build_jac = false, build_symfuncs = false,
-    build_paramjac = false)
-@timeit to "ODEProb" oprob=ODEProblem(rn, convert.(Float64, initialpop), (0.0, tf))
+@timeit to "addodes" addodes!(
+    rn; build_jac = false, build_symfuncs = false,
+    build_paramjac = false
+)
+@timeit to "ODEProb" oprob = ODEProblem(rn, convert.(Float64, initialpop), (0.0, tf))
 show(to)
 println()
 
-# note solvers run faster the second time 
+# note solvers run faster the second time
 
 # I haven't been able to successfully solve the system with Rodas4/Rodas5
 #reset_timer!(to); @timeit to "Rodas4" begin sol = solve(oprob,Rodas4(autodiff=false),dense=false,calck=false); end; show(to)

--- a/examples/test_bcr_odes.jl
+++ b/examples/test_bcr_odes.jl
@@ -2,7 +2,7 @@
 # plot a specific observable and compare to the BioNetGen solution
 
 using DiffEqBase, Catalyst, Plots, OrdinaryDiffEq, Sundials, DataFrames, CSVFiles,
-      LinearAlgebra, SparseArrays
+    LinearAlgebra, SparseArrays
 using ReactionNetworkImporters
 using TimerOutputs
 
@@ -18,21 +18,25 @@ datadir = joinpath(@__DIR__, "../data/bcr")
 fname = joinpath(datadir, "bcr.net")
 gdatfile = joinpath(datadir, "bcr.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(load(File(format"CSV", gdatfile), header_exists = true,
-    spacedelim = true))
+gdatdf = DataFrame(
+    load(
+        File(format"CSV", gdatfile), header_exists = true,
+        spacedelim = true
+    )
+)
 println("done")
 
-# we'll time the DiffEq solvers 
+# we'll time the DiffEq solvers
 const to = TimerOutput()
 reset_timer!(to)
 
 # BioNetGen network
-@timeit to "bionetgen" prnbng=loadrxnetwork(BNGNetwork(), fname);
+@timeit to "bionetgen" prnbng = loadrxnetwork(BNGNetwork(), fname);
 show(to)
 rnbng = prnbng.rn
-@timeit to "bODESystem" bosys=convert(ODESystem, rnbng)
+@timeit to "bODESystem" bosys = convert(ODESystem, rnbng)
 show(to)
-@timeit to "bODEProb" boprob=ODEProblem(bosys, Float64[], (0.0, tf), Float64[])
+@timeit to "bODEProb" boprob = ODEProblem(bosys, Float64[], (0.0, tf), Float64[])
 show(to)
 u = zeros(numspecies(rnbng))
 p = zeros(length(parameters(rnbng)))
@@ -48,8 +52,8 @@ end
 show(to)
 println()
 
-# DiffEq solver 
-#reset_timer!(to); 
+# DiffEq solver
+#reset_timer!(to);
 #@timeit to "BNG_CVODE_BDF-LU-1" begin bsol = solve(boprob, CVODE_BDF(), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
 #@timeit to "BNG_CVODE_BDF-LU-2" begin bsol = solve(boprob, CVODE_BDF(), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
 #@timeit to "BNG_CVODE_BDF-GMRES-1" begin bsol = solve(boprob, CVODE_BDF(linear_solver=:GMRES), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
@@ -58,13 +62,17 @@ println()
 #@timeit to "KenCarp4-1" begin sol = solve(boprob,KenCarp4(autodiff=false,linsolve=LinSolveFactorize(lu)), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
 #@timeit to "KenCarp4-2" begin bsol = solve(boprob,KenCarp4(autodiff=false,linsolve=LinSolveFactorize(lu)), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
 @timeit to "KenCarp4-1" begin
-    sol = solve(boprob, KenCarp4(autodiff = false), abstol = 1e-8,
-        reltol = 1e-8, saveat = 1.0)
+    sol = solve(
+        boprob, KenCarp4(autodiff = false), abstol = 1.0e-8,
+        reltol = 1.0e-8, saveat = 1.0
+    )
 end;
 show(to);
 @timeit to "KenCarp4-2" begin
-    bsol = solve(boprob, KenCarp4(autodiff = false),
-        abstol = 1e-8, reltol = 1e-8, saveat = 1.0)
+    bsol = solve(
+        boprob, KenCarp4(autodiff = false),
+        abstol = 1.0e-8, reltol = 1.0e-8, saveat = 1.0
+    )
 end;
 show(to);
 
@@ -73,10 +81,14 @@ show(to);
 
 if doplot
     plotlyjs()
-    plot(gdatdf[!, :time][2:end], gdatdf[!, :Activated_Syk][2:end], xscale = :log10,
-        label = "AsykGroup", linestyle = :dot)
-    plot!(bsol.t[2:end], sol[Activated_Syk][2:end], label = "Activated_Syk",
-        xscale = :log10)
+    plot(
+        gdatdf[!, :time][2:end], gdatdf[!, :Activated_Syk][2:end], xscale = :log10,
+        label = "AsykGroup", linestyle = :dot
+    )
+    plot!(
+        bsol.t[2:end], sol[Activated_Syk][2:end], label = "Activated_Syk",
+        xscale = :log10
+    )
 end
 
 # test the error, note may be large in abs value though small relatively

--- a/src/ReactionNetworkImporters.jl
+++ b/src/ReactionNetworkImporters.jl
@@ -10,7 +10,7 @@ using Symbolics: operation, unwrap
 # u = S₁(t)
 function funcsym(S::Symbol, t, args...)
     S = Symbol(S, args...)
-    only(@species $(S)(t))
+    return only(@species $(S)(t))
 end
 
 abstract type NetworkFileFormat end
@@ -56,9 +56,11 @@ struct ParsedReactionNetwork
     "Dict from group name (as string) to corresponding symbolic variable"
     groupstosyms::Any
 end
-function ParsedReactionNetwork(rn::ReactionSystem; u0 = nothing, p = nothing,
-        varstonames = nothing, groupstosyms = nothing)
-    ParsedReactionNetwork(rn, u0, p, varstonames, groupstosyms)
+function ParsedReactionNetwork(
+        rn::ReactionSystem; u0 = nothing, p = nothing,
+        varstonames = nothing, groupstosyms = nothing
+    )
+    return ParsedReactionNetwork(rn, u0, p, varstonames, groupstosyms)
 end
 
 export BNGNetwork, MatrixNetwork, ParsedReactionNetwork, ComplexMatrixNetwork

--- a/src/parsing_routines_matrixnetworks.jl
+++ b/src/parsing_routines_matrixnetworks.jl
@@ -26,9 +26,11 @@ struct MatrixNetwork{S, T, U, V, W, X} <: NetworkFileFormat
     """independent variable, time """
     t::X
 end
-function MatrixNetwork(rateexprs, substoich, prodstoich; species = Any[], params = Any[],
-        t = nothing)
-    MatrixNetwork(rateexprs, substoich, prodstoich, species, params, t)
+function MatrixNetwork(
+        rateexprs, substoich, prodstoich; species = Any[], params = Any[],
+        t = nothing
+    )
+    return MatrixNetwork(rateexprs, substoich, prodstoich, species, params, t)
 end
 
 # for dense matrices
@@ -73,11 +75,15 @@ mn = MatrixNetwork(rateexprs, substoich, prodstoich; species = species, params =
 parsed_network = loadrxnetwork(mn, name = :MyReactionSystem)
 ```
 """
-function loadrxnetwork(mn::MatrixNetwork{S, T, U, V, W, X};
-        name = gensym(:ReactionSystem)) where {S <: AbstractVector,
+function loadrxnetwork(
+        mn::MatrixNetwork{S, T, U, V, W, X};
+        name = gensym(:ReactionSystem)
+    ) where {
+        S <: AbstractVector,
         T <: Matrix, U <: Matrix{Int},
         V <: AbstractVector,
-        W <: AbstractVector, X <: Any}
+        W <: AbstractVector, X <: Any,
+    }
     sz = size(mn.substoich)
     @assert sz == size(mn.prodstoich)
     numspecs = sz[1]
@@ -114,17 +120,21 @@ function loadrxnetwork(mn::MatrixNetwork{S, T, U, V, W, X};
         rxs[j] = Reaction(mn.rateexprs[j], subs, prods, sstoich, pstoich)
     end
 
-    ParsedReactionNetwork(ReactionSystem(rxs, t, species, mn.params; name = name))
+    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, mn.params; name = name))
 end
 
 # for sparse matrices
-function loadrxnetwork(mn::MatrixNetwork{S, T, U, V, W, X};
-        name = gensym(:ReactionSystem)) where {S <: AbstractVector,
+function loadrxnetwork(
+        mn::MatrixNetwork{S, T, U, V, W, X};
+        name = gensym(:ReactionSystem)
+    ) where {
+        S <: AbstractVector,
         T <: SparseMatrixCSC,
         U <:
         SparseMatrixCSC{Int, Int},
         V <: AbstractVector,
-        W <: AbstractVector, X <: Any}
+        W <: AbstractVector, X <: Any,
+    }
     sz = size(mn.substoich)
     @assert sz == size(mn.prodstoich)
     numspecs = sz[1]
@@ -166,7 +176,7 @@ function loadrxnetwork(mn::MatrixNetwork{S, T, U, V, W, X};
         rxs[j] = Reaction(mn.rateexprs[j], subs, prods, sstoich, pstoich)
     end
 
-    ParsedReactionNetwork(ReactionSystem(rxs, t, species, mn.params; name = name))
+    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, mn.params; name = name))
 end
 
 """
@@ -206,17 +216,23 @@ struct ComplexMatrixNetwork{S, T, U, V, W, X} <: NetworkFileFormat
     """independent variable, time """
     t::X
 end
-function ComplexMatrixNetwork(rateexprs, stoichmat, incidencemat; species = Any[],
-        params = Any[], t = nothing)
-    ComplexMatrixNetwork(rateexprs, stoichmat, incidencemat, species, params, t)
+function ComplexMatrixNetwork(
+        rateexprs, stoichmat, incidencemat; species = Any[],
+        params = Any[], t = nothing
+    )
+    return ComplexMatrixNetwork(rateexprs, stoichmat, incidencemat, species, params, t)
 end
 
 # for Dense matrices version
-function loadrxnetwork(cmn::ComplexMatrixNetwork{S, T, U, V, W, X};
-        name = gensym(:ReactionSystem)) where {S <: AbstractVector,
+function loadrxnetwork(
+        cmn::ComplexMatrixNetwork{S, T, U, V, W, X};
+        name = gensym(:ReactionSystem)
+    ) where {
+        S <: AbstractVector,
         T <: Matrix, U <: Matrix{Int},
         V <: AbstractVector,
-        W <: AbstractVector, X <: Any}
+        W <: AbstractVector, X <: Any,
+    }
     numspecs, numcomp = size(cmn.stoichmat)
     @assert all(>=(0), cmn.stoichmat)
     @assert numcomp == size(cmn.incidencemat, 1)
@@ -238,30 +254,40 @@ function loadrxnetwork(cmn::ComplexMatrixNetwork{S, T, U, V, W, X};
         ps_ind = findall(!iszero, @view cmn.stoichmat[:, pc_ind[i][1]])
 
         if isempty(ss_ind) && !isempty(ps_ind)
-            rxs[i] = Reaction(cmn.rateexprs[i], nothing, species[ps_ind],
-                nothing, cmn.stoichmat[ps_ind, pc_ind[i][1]])
+            rxs[i] = Reaction(
+                cmn.rateexprs[i], nothing, species[ps_ind],
+                nothing, cmn.stoichmat[ps_ind, pc_ind[i][1]]
+            )
 
         elseif !isempty(ss_ind) && isempty(ps_ind)
-            rxs[i] = Reaction(cmn.rateexprs[i], species[ss_ind], nothing,
-                cmn.stoichmat[ss_ind, sc_ind[i][1]], nothing)
+            rxs[i] = Reaction(
+                cmn.rateexprs[i], species[ss_ind], nothing,
+                cmn.stoichmat[ss_ind, sc_ind[i][1]], nothing
+            )
         else
-            rxs[i] = Reaction(cmn.rateexprs[i], species[ss_ind], species[ps_ind],
+            rxs[i] = Reaction(
+                cmn.rateexprs[i], species[ss_ind], species[ps_ind],
                 cmn.stoichmat[ss_ind, sc_ind[i][1]],
-                cmn.stoichmat[ps_ind, pc_ind[i][1]])
+                cmn.stoichmat[ps_ind, pc_ind[i][1]]
+            )
         end
     end
 
-    ParsedReactionNetwork(ReactionSystem(rxs, t, species, cmn.params; name = name))
+    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, cmn.params; name = name))
 end
 
 # for sparse matrices version
-function loadrxnetwork(cmn::ComplexMatrixNetwork{S, T, U, V, W, X};
-        name = gensym(:ReactionSystem)) where {S <: AbstractVector,
+function loadrxnetwork(
+        cmn::ComplexMatrixNetwork{S, T, U, V, W, X};
+        name = gensym(:ReactionSystem)
+    ) where {
+        S <: AbstractVector,
         T <: SparseMatrixCSC,
         U <:
         SparseMatrixCSC{Int, Int},
         V <: AbstractVector,
-        W <: AbstractVector, X <: Any}
+        W <: AbstractVector, X <: Any,
+    }
     numspecs, numcomp = size(cmn.stoichmat)
     @assert all(>=(0), cmn.stoichmat)
     @assert numcomp == size(cmn.incidencemat, 1)
@@ -283,18 +309,24 @@ function loadrxnetwork(cmn::ComplexMatrixNetwork{S, T, U, V, W, X};
         ps_ind = @view rows[nzrange(cmn.stoichmat, pc_ind[i][1])]
 
         if isempty(ss_ind) && !isempty(ps_ind)
-            rxs[i] = Reaction(cmn.rateexprs[i], nothing, species[ps_ind],
-                nothing, vals[nzrange(cmn.stoichmat, pc_ind[i][1])])
+            rxs[i] = Reaction(
+                cmn.rateexprs[i], nothing, species[ps_ind],
+                nothing, vals[nzrange(cmn.stoichmat, pc_ind[i][1])]
+            )
 
         elseif !isempty(ss_ind) && isempty(ps_ind)
-            rxs[i] = Reaction(cmn.rateexprs[i], species[ss_ind], nothing,
-                vals[nzrange(cmn.stoichmat, sc_ind[i][1])], nothing)
+            rxs[i] = Reaction(
+                cmn.rateexprs[i], species[ss_ind], nothing,
+                vals[nzrange(cmn.stoichmat, sc_ind[i][1])], nothing
+            )
         else
-            rxs[i] = Reaction(cmn.rateexprs[i], species[ss_ind], species[ps_ind],
+            rxs[i] = Reaction(
+                cmn.rateexprs[i], species[ss_ind], species[ps_ind],
                 vals[nzrange(cmn.stoichmat, sc_ind[i][1])],
-                vals[nzrange(cmn.stoichmat, pc_ind[i][1])])
+                vals[nzrange(cmn.stoichmat, pc_ind[i][1])]
+            )
         end
     end
 
-    ParsedReactionNetwork(ReactionSystem(rxs, t, species, cmn.params; name = name))
+    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, cmn.params; name = name))
 end

--- a/src/parsing_routines_rssafiles.jl
+++ b/src/parsing_routines_rssafiles.jl
@@ -8,7 +8,7 @@ function parse_species(ft::RSSANetwork, fname)
         end
     end
 
-    specs_ic
+    return specs_ic
 end
 
 function parse_reactions(ft::RSSANetwork, fname)
@@ -25,11 +25,13 @@ function parse_reactions(ft::RSSANetwork, fname)
         end
     end
 
-    rxstrs, rxrates
+    return rxstrs, rxrates
 end
 
-function build_rxnetwork(ft::RSSANetwork, networkname, rxstrs, rxrates; printrxs = false,
-        kwargs...)
+function build_rxnetwork(
+        ft::RSSANetwork, networkname, rxstrs, rxrates; printrxs = false,
+        kwargs...
+    )
 
     # string representing the network
     rxiobuf = IOBuffer()
@@ -48,7 +50,7 @@ function build_rxnetwork(ft::RSSANetwork, networkname, rxstrs, rxrates; printrxs
     # build the network using Catalyst
     rn = eval(Meta.parse(rnstr))
 
-    rn, rnstr
+    return rn, rnstr
 end
 
 function get_init_condit(ft::RSSANetwork, rn, specs_ic)
@@ -57,7 +59,7 @@ function get_init_condit(ft::RSSANetwork, rn, specs_ic)
         icvec[i] = specs_ic[sym]
     end
 
-    icvec
+    return icvec
 end
 
 # for parsing the simple format from the book by Thanh et al.
@@ -73,5 +75,5 @@ function loadrxnetwork(ft::RSSANetwork, specs_ic_file, rxs_file; kwargs...)
     rn, rnstr = build_rxnetwork(ft, networkname, rxstrs, rxrates; kwargs...)
     initialpop = get_init_condit(ft, rn, specs_ic)
 
-    ParsedReactionNetwork(rn, initialpop)
+    return ParsedReactionNetwork(rn, initialpop)
 end

--- a/test/test_higherorder_odes.jl
+++ b/test/test_higherorder_odes.jl
@@ -5,7 +5,7 @@ using ReactionNetworkImporters
 # parameters
 doplot = false
 networkname = "HigherOrder"
-tf = 1e-2
+tf = 1.0e-2
 nsteps = 2000
 
 # BNG simulation data
@@ -13,8 +13,12 @@ datadir = joinpath(@__DIR__, "../data/higherorder")
 fname = joinpath(datadir, "higherorder.net")
 gdatfile = joinpath(datadir, "higherorder.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(load(File{format"CSV"}(gdatfile), header_exists = true,
-    spacedelim = true))
+gdatdf = DataFrame(
+    load(
+        File{format"CSV"}(gdatfile), header_exists = true,
+        spacedelim = true
+    )
+)
 println("done")
 
 # load the BNG reaction network in DiffEqBio
@@ -32,7 +36,7 @@ boprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
 Asol = gdatdf[!, :A]
 
 # note solvers run _much_ faster the second time
-bsol = solve(boprob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = tf / nsteps);
+bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps);
 
 # if doplot
 #     plotlyjs()
@@ -43,4 +47,4 @@ bsol = solve(boprob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = tf / nste
 # end
 
 @test all(bsol.t .== gdatdf[!, :time])
-@test all(abs.(gdatdf[!, :A] - bsol[A]) .< 1e-6 .* abs.(gdatdf[!, :A]))
+@test all(abs.(gdatdf[!, :A] - bsol[A]) .< 1.0e-6 .* abs.(gdatdf[!, :A]))

--- a/test/test_mats.jl
+++ b/test/test_mats.jl
@@ -12,21 +12,29 @@ end
 
 @parameters k1 k2 k3 k4 k5
 pars = [k1, k2, k3, k4, k5]
-substoich = [2 0 1 0 0;
-             0 1 1 0 0;
-             0 0 0 1 3]
-prodstoich = [0 2 0 1 3;
-              1 0 0 1 0;
-              0 0 1 0 0]
-compstoichmat = [2 0 1 0 0 3;
-                 0 1 1 0 0 0;
-                 0 0 0 1 3 0]
-incidencemat = [-1 1 0 0 0;
-                1 -1 0 0 0;
-                0 0 -1 1 0;
-                0 0 1 -1 0;
-                0 0 0 0 -1;
-                0 0 0 0 1]
+substoich = [
+    2 0 1 0 0;
+    0 1 1 0 0;
+    0 0 0 1 3
+]
+prodstoich = [
+    0 2 0 1 3;
+    1 0 0 1 0;
+    0 0 1 0 0
+]
+compstoichmat = [
+    2 0 1 0 0 3;
+    0 1 1 0 0 0;
+    0 0 0 1 3 0
+]
+incidencemat = [
+    -1 1 0 0 0;
+    1 -1 0 0 0;
+    0 0 -1 1 0;
+    0 0 1 -1 0;
+    0 0 0 0 -1;
+    0 0 0 0 1
+]
 mn1 = MatrixNetwork(pars, substoich, prodstoich; params = pars)
 prn = loadrxnetwork(mn1; name = nameof(rs)) # dense version
 @test rs == complete(prn.rn)
@@ -37,8 +45,10 @@ prn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
 cmn1 = ComplexMatrixNetwork(pars, compstoichmat, incidencemat; params = pars)
 prn = loadrxnetwork(cmn1; name = nameof(rs))
 @test rs == complete(prn.rn)
-cmn2 = ComplexMatrixNetwork(pars, sparse(compstoichmat), sparse(incidencemat);
-    params = pars)
+cmn2 = ComplexMatrixNetwork(
+    pars, sparse(compstoichmat), sparse(incidencemat);
+    params = pars
+)
 prn = loadrxnetwork(cmn2; name = nameof(rs))
 @test rs == complete(prn.rn)
 
@@ -60,8 +70,10 @@ prn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
 cmn1 = ComplexMatrixNetwork(convert.(Float64, 1:5), compstoichmat, incidencemat)
 prn = loadrxnetwork(cmn1; name = nameof(rs))
 @test rs == complete(prn.rn)
-cmn2 = ComplexMatrixNetwork(convert.(Float64, 1:5), sparse(compstoichmat),
-    sparse(incidencemat))
+cmn2 = ComplexMatrixNetwork(
+    convert.(Float64, 1:5), sparse(compstoichmat),
+    sparse(incidencemat)
+)
 prn = loadrxnetwork(cmn2; name = nameof(rs))
 @test rs == complete(prn.rn)
 
@@ -80,16 +92,22 @@ rates = [k1 * A, k2, k3, k4, k5]
 mn1 = MatrixNetwork(rates, substoich, prodstoich; species = species, params = pars)
 prn = loadrxnetwork(mn1; name = nameof(rs)) # dense version
 @test rs == complete(prn.rn)
-mn2 = MatrixNetwork(rates, sparse(substoich), sparse(prodstoich); species = species,
-    params = pars)
+mn2 = MatrixNetwork(
+    rates, sparse(substoich), sparse(prodstoich); species = species,
+    params = pars
+)
 prn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
 @test rs == complete(prn.rn)
 
-cmn1 = ComplexMatrixNetwork(rates, compstoichmat, incidencemat; species = species,
-    params = pars)
+cmn1 = ComplexMatrixNetwork(
+    rates, compstoichmat, incidencemat; species = species,
+    params = pars
+)
 prn = loadrxnetwork(cmn1; name = nameof(rs))
 @test rs == complete(prn.rn)
-cmn2 = ComplexMatrixNetwork(rates, sparse(compstoichmat), sparse(incidencemat);
-    species = species, params = pars)
+cmn2 = ComplexMatrixNetwork(
+    rates, sparse(compstoichmat), sparse(incidencemat);
+    species = species, params = pars
+)
 prn = loadrxnetwork(cmn2; name = nameof(rs))
 @test rs == complete(prn.rn)

--- a/test/test_nullrxs_odes.jl
+++ b/test/test_nullrxs_odes.jl
@@ -13,8 +13,12 @@ datadir = joinpath(@__DIR__, "../data/nullrxs")
 fname = joinpath(datadir, "birth-death.net")
 gdatfile = joinpath(datadir, "birth-death.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(load(File{format"CSV"}(gdatfile), header_exists = true,
-    spacedelim = true))
+gdatdf = DataFrame(
+    load(
+        File{format"CSV"}(gdatfile), header_exists = true,
+        spacedelim = true
+    )
+)
 println("done")
 
 # load the BNG reaction network in DiffEqBio
@@ -28,7 +32,7 @@ boprob = ODEProblem(rn, u0, (0.0, tf), p)
 @test isequal(prnbng.u0, prnbng.u₀)
 
 # note solvers run _much_ faster the second time
-bsol = solve(boprob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = tf / nsteps)
+bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps)
 
 if doplot
     plotlyjs()
@@ -39,5 +43,7 @@ if doplot
 end
 
 @test all(bsol.t .== gdatdf[!, :time])
-@test all(abs.(gdatdf[!, :Atot] - bsol[1, :]) .<
-          max.(1e-8 .* abs.(gdatdf[!, :Atot]), 1e-12))
+@test all(
+    abs.(gdatdf[!, :Atot] - bsol[1, :]) .<
+        max.(1.0e-8 .* abs.(gdatdf[!, :Atot]), 1.0e-12)
+)

--- a/test/test_repressilator_odes.jl
+++ b/test/test_repressilator_odes.jl
@@ -14,8 +14,12 @@ datadir = joinpath(@__DIR__, "../data/repressilator")
 fname = joinpath(datadir, "Repressilator.net")
 gdatfile = joinpath(datadir, "Repressilator.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(load(File{format"CSV"}(gdatfile), header_exists = true,
-    spacedelim = true))
+gdatdf = DataFrame(
+    load(
+        File{format"CSV"}(gdatfile), header_exists = true,
+        spacedelim = true
+    )
+)
 println("done")
 
 # load the BNG reaction network in DiffEqBio
@@ -32,7 +36,7 @@ boprob = ODEProblem(rn, u0, (0.0, tf), p)
 bngsol = gdatdf[!, :pTetR]
 
 # note solvers run _much_ faster the second time
-bsol = solve(boprob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = tf / nsteps);
+bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps);
 @unpack pTetR = rn
 
 # if doplot
@@ -43,4 +47,4 @@ bsol = solve(boprob, Tsit5(), abstol = 1e-12, reltol = 1e-12, saveat = tf / nste
 # end
 
 @test all(bsol.t .== gdatdf[!, :time])
-@test all(abs.(gdatdf[!, :pTetR] - bsol[pTetR]) .< 1e-6 .* abs.(gdatdf[!, :pTetR]))
+@test all(abs.(gdatdf[!, :pTetR] - bsol[pTetR]) .< 1.0e-6 .* abs.(gdatdf[!, :pTetR]))


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)