### PR TITLE
Breaking: update for Catalyst v16, drop ParsedReactionNetwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 Manifest.toml
 .vscode
 .vscode/*
+.claude
+.claude/*
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,33 @@
+# History
+
+## v1.0.0
+
+Breaking release for compatibility with Catalyst.jl v16.
+
+### Breaking changes
+
+- `loadrxnetwork` now returns a `ReactionSystem` directly instead of a
+  `ParsedReactionNetwork`. The `ParsedReactionNetwork` type has been removed.
+- Initial conditions and parameter values from BNG files are stored as
+  `initial_conditions` on the `ReactionSystem`, and are also available via the
+  Catalyst metadata accessors `Catalyst.get_u0_map(rn)` and
+  `Catalyst.get_parameter_map(rn)`.
+- BNG species name mappings and group symbols are stored as system metadata,
+  accessible via the new exported accessors `get_varstonames(rn)` and
+  `get_groupstosyms(rn)`.
+- `ModelingToolkit` is no longer a dependency; replaced by `ModelingToolkitBase`.
+- Test dependency `CSVFiles` replaced by `CSV.jl`.
+- Requires Catalyst.jl v16+.
+
+### Migration guide
+
+| Before (v0.x)                              | After (v1.0)                        |
+| ------------------------------------------ | ----------------------------------- |
+| `prn = loadrxnetwork(BNGNetwork(), file)`  | `rn = loadrxnetwork(BNGNetwork(), file)` |
+| `prn.rn`                                   | `rn` (the return value itself)      |
+| `prn.u0`                                   | `Catalyst.get_u0_map(rn)`          |
+| `prn.p`                                    | `Catalyst.get_parameter_map(rn)`   |
+| `prn.varstonames`                          | `get_varstonames(rn)`              |
+| `prn.groupstosyms`                         | `get_groupstosyms(rn)`             |
+| `rs == prn.rn`                             | `Catalyst.isequivalent(rs, rn)`    |
+| `prn = loadrxnetwork(mn)`; `prn.rn`       | `rn = loadrxnetwork(mn)`           |

--- a/Project.toml
+++ b/Project.toml
@@ -1,33 +1,35 @@
 name = "ReactionNetworkImporters"
 uuid = "b4db0fb7-de2a-5028-82bf-5021f5cfa881"
 authors = ["Samuel Isaacson <isaacsas@users.noreply.github.com>"]
-version = "0.16.1"
+version = "1.0.0"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 Aqua = "0.8"
-CSVFiles = "1"
-Catalyst = "15.0"
+CSV = "0.10"
+Catalyst = "16"
 DataFrames = "1.7"
 DataStructures = "0.18.13, 0.19"
 LinearAlgebra = "1.10"
-ModelingToolkit = "9.72"
+ModelingToolkitBase = "1.17"
 OrdinaryDiffEqTsit5 = "1.1"
 SafeTestsets = "0.1"
 SparseArrays = "1.10"
-Symbolics = "6.31.1"
+SymbolicUtils = "4.9.1"
+Symbolics = "7.13.0"
 Test = "1"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
@@ -35,4 +37,4 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CSVFiles", "DataFrames", "LinearAlgebra", "OrdinaryDiffEqTsit5", "SafeTestsets", "Test"]
+test = ["Aqua", "CSV", "DataFrames", "LinearAlgebra", "OrdinaryDiffEqTsit5", "SafeTestsets", "Test"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ command in the bngl file outputs a reduced network description, i.e. a
 Catalyst `ReactionSystem` as:
 
 ```julia
-using ReactionNetworkImporters
+using ReactionNetworkImporters, Catalyst
 fname = "PATH/TO/Repressilator.net"
 rn = loadrxnetwork(BNGNetwork(), fname)
 ```
@@ -70,7 +70,7 @@ Given the loaded `ReactionSystem`, we can construct and solve the corresponding
 ODE model by
 
 ```julia
-using OrdinaryDiffEq, Catalyst
+using OrdinaryDiffEqTsit5
 rn = complete(rn)   # mark the reaction network as complete
 tf = 100000.0
 oprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
@@ -95,6 +95,8 @@ network using the `@reaction_network` macro, and then show how to build the same
 network from these matrices using `ReactionNetworkImporters`:
 
 ```julia
+using ReactionNetworkImporters, Catalyst
+
 # Catalyst network from the macro:
 rs = @reaction_network testnetwork begin
     k1, 2A --> B
@@ -121,8 +123,7 @@ mn = MatrixNetwork(pars, substoich, prodstoich; species = species,
 rn = loadrxnetwork(mn; name = :testnetwork) # dense version
 
 # test the two networks are the same
-using Catalyst: isequivalent
-@assert isequivalent(rs, complete(rn))
+@assert Catalyst.isequivalent(rs, complete(rn))
 
 # network from reaction complex stoichiometry
 stoichmat = [2 0 1 0 0 3;
@@ -139,7 +140,7 @@ cmn = ComplexMatrixNetwork(pars, stoichmat, incidencemat; species = species,
 rn = loadrxnetwork(cmn; name = :testnetwork)
 
 # test the two networks are the same
-@assert isequivalent(rs, complete(rn))
+@assert Catalyst.isequivalent(rs, complete(rn))
 ```
 
 The basic usages are

--- a/README.md
+++ b/README.md
@@ -45,44 +45,40 @@ Catalyst `ReactionSystem` as:
 ```julia
 using ReactionNetworkImporters
 fname = "PATH/TO/Repressilator.net"
-prnbng = loadrxnetwork(BNGNetwork(), fname)
+rn = loadrxnetwork(BNGNetwork(), fname)
 ```
 
 Here `BNGNetwork` is a type specifying the file format that is being loaded.
-`prnbng` is a `ParsedReactionNetwork` structure with the following fields:
+`loadrxnetwork` returns a Catalyst `ReactionSystem` (**not** marked as complete
+by default). Initial conditions, parameter values, and BNG-specific mappings are
+stored as system metadata and can be accessed via:
 
-  - `rn`, a Catalyst `ReactionSystem`. **Note** this system is *not* marked
-    complete by default (see the [Catalyst docs](https://catalyst.sciml.ai/) for
-    a discussion of completeness of systems).
-  - `u0`, a `Dict` mapping initial condition symbolic variables to numeric values
-    and/or symbolic expressions.
-  - `p`, a `Dict` mapping parameter symbolic variables to numeric values and/or
-    symbolic expressions.
-  - `varstonames`, a `Dict` mapping the internal symbolic variable of a species
-    used in the generated `ReactionSystem` to a `String` generated from the name
-    in the .net file. This is necessary as BioNetGen can generate exceptionally
-    long species names, involving characters that lead to malformed species names
-    when used with `Catalyst`.
-  - `groupstosyms`, a `Dict` mapping the `String`s representing names for any
-    groups defined in the BioNetGen file to the corresponding symbolic variable
-    representing the `ModelingToolkit` symbolic observable associated with the
-    group.
+  - `Catalyst.get_u0_map(rn)`, a `Dict` mapping initial condition symbolic
+    variables to numeric values and/or symbolic expressions.
+  - `Catalyst.get_parameter_map(rn)`, a `Dict` mapping parameter symbolic
+    variables to numeric values and/or symbolic expressions.
+  - `get_varstonames(rn)`, a `Dict` mapping the internal symbolic variable of a
+    species used in the generated `ReactionSystem` to a `String` generated from
+    the name in the .net file. This is necessary as BioNetGen can generate
+    exceptionally long species names, involving characters that lead to
+    malformed species names when used with `Catalyst`.
+  - `get_groupstosyms(rn)`, a `Dict` mapping the `String`s representing names
+    for any groups defined in the BioNetGen file to the corresponding symbolic
+    variable representing the symbolic observable associated with the group.
 
-Given `prnbng`, we can construct and solve the corresponding ODE model for the
-reaction system by
+Given the loaded `ReactionSystem`, we can construct and solve the corresponding
+ODE model by
 
 ```julia
 using OrdinaryDiffEq, Catalyst
-rn = complete(prnbng.rn)   # get the reaction network and mark it complete
+rn = complete(rn)   # mark the reaction network as complete
 tf = 100000.0
 oprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
 sol = solve(oprob, Tsit5(), saveat = tf / 1000.0)
 ```
 
 Note that we specify empty parameter and initial condition vectors as these are
-already stored in the generated `ReactionSystem`, `rn`. A `Dict` mapping each
-symbolic species and parameter to its initial value or symbolic expression can
-be obtained using `ModelingToolkit.defaults(rn)`.
+already stored in the generated `ReactionSystem` via `initial_conditions`.
 
 See the [Catalyst documentation](https://docs.sciml.ai/Catalyst/stable/) for how to
 generate ODE, SDE, jump and other types of models.
@@ -122,10 +118,11 @@ prodstoich = [0 2 0 1 3;
               0 0 1 0 0]
 mn = MatrixNetwork(pars, substoich, prodstoich; species = species,
     params = pars) # a matrix network
-prn = loadrxnetwork(mn; name = :testnetwork) # dense version
+rn = loadrxnetwork(mn; name = :testnetwork) # dense version
 
 # test the two networks are the same
-@assert rs == prn.rn
+using Catalyst: isequivalent
+@assert isequivalent(rs, complete(rn))
 
 # network from reaction complex stoichiometry
 stoichmat = [2 0 1 0 0 3;
@@ -139,10 +136,10 @@ incidencemat = [-1 1 0 0 0;
                 0 0 0 0 1]
 cmn = ComplexMatrixNetwork(pars, stoichmat, incidencemat; species = species,
     params = pars)  # a complex matrix network
-prn = loadrxnetwork(cmn)
+rn = loadrxnetwork(cmn; name = :testnetwork)
 
 # test the two networks are the same
-@assert rs == prn.rn
+@assert isequivalent(rs, complete(rn))
 ```
 
 The basic usages are
@@ -150,17 +147,17 @@ The basic usages are
 ```julia
 mn = MatrixNetwork(rateexprs, substoich, prodstoich; species = Any[],
     params = Any[], t = nothing)
-prn = loadrxnetwork(mn::MatrixNetwork)
+rn = loadrxnetwork(mn::MatrixNetwork)
 
 cmn = ComplexMatrixNetwork(rateexprs, stoichmat, incidencemat; species = Any[],
     params = Any[], t = nothing)
-prn = loadrxnetwork(cmn::ComplexMatrixNetwork)
+rn = loadrxnetwork(cmn::ComplexMatrixNetwork)
 ```
 
 Here `MatrixNetwork` and `ComplexMatrixNetwork` are the types, which select that
 we are constructing a substrate/product stoichiometric matrix-based or a
 reaction complex matrix-based stoichiometric representation as input. See the
-[Catalyst.jl API](hhttps://docs.sciml.ai/Catalyst/stable/api/catalyst_api/) for more
+[Catalyst.jl API](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/) for more
 discussion on these matrix representations, and how Catalyst handles symbolic
 reaction rate expressions. These two types have the following fields:
 
@@ -171,18 +168,18 @@ reaction rate expressions. These two types have the following fields:
     involving parameters and species like `k*A`.
 
   - matrix inputs
-    
+
       + For `MatrixNetwork`
-        
+
           * `substoich`, a number of species by number of reactions matrix with entry
             `(i,j)` giving the stoichiometric coefficient of species `i` as a
             substrate in reaction `j`.
           * `prodstoich`, a number of species by number of reactions matrix with entry
             `(i,j)` giving the stoichiometric coefficient of species `i` as a product
             in reaction `j`.
-    
+
       + For `ComplexMatrixNetwork`
-        
+
           * `stoichmat`, the complex stoichiometry matrix [defined
             here](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.complexstoichmat).
           * `incidencemat`, the complex incidence matrix [defined
@@ -192,20 +189,16 @@ reaction rate expressions. These two types have the following fields:
     Each species should be dependent on the same time variable (`t` in the example
     above).
   - `parameters`, a vector of symbolic variables representing each parameter in
-    the network. Can be constructed with the
-    [ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/)
-    `@parameters` macro. If no parameters are used it is an optional keyword.
+    the network. Can be constructed with the Catalyst.jl `@parameters` macro. If
+    no parameters are used it is an optional keyword.
   - `t`, an optional Symbolics.jl variable representing time as the independent
     variable of the reaction network. If not provided `Catalyst.default_t()` is
     used to determine the default time variable.
 
-For both input types, `loadrxnetwork` returns a `ParsedReactionNetwork`, `prn`,
-with only the field, `prn.rn`, filled in. `prn.rn` corresponds to the generated
-[Catalyst.jl
-`ReactionSystem`](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.ReactionSystem)
-that represents the network. **Note**, `prn.rn` is not marked as complete by
-default and must be manually completed by setting `rn = complete(prn.rn)` before
-creating an `ODEProblem` or such, see the Catalyst docs for details.
+For both input types, `loadrxnetwork` returns a Catalyst `ReactionSystem`. The
+system is **not** marked as complete by default and must be manually completed by
+calling `rn = complete(rn)` before creating an `ODEProblem` or such; see the
+Catalyst docs for details.
 
 Dispatches are added if `substoich` and `prodstoich` both have the type
 `SparseMatrixCSC`in case of `MatrixNetwork` (or `stoichmat` and `incidencemat`
@@ -217,12 +210,3 @@ If the keyword argument `species` is not set, the resulting reaction network
 will simply name the species `S1`, `S2`,..., `SN` for a system with `N` total
 species. `params` defaults to an empty vector, so that it does not need to be
 set for systems with no parameters.
-
-<!-- ### Loading a RSSA format network file
-As the licensing is unclear we can not redistribute any example RSSA formatted networks. They can be downloaded from the model collection link listed above. Assuming you've saved both a reaction network file and corresponding initial condition file, they can be loaded as
-```julia
-initialconditionf = "PATH/TO/FILE"
-networkf = "PATH/TO/FILE"
-rssarn = loadrxnetwork(RSSANetwork(), "RSSARxSys", initialconditionf, networkf)
-```
-Here `RSSANetwork` specifies the type of the file to parse, and `RSSARxSys` gives the type of the generated `reaction_network`. `rssarn` is again a `ParsedReactionNetwork`, but only the `rn` and `u0` fields will now be relevant (the remaining fields will be set to `nothing`). -->

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ reaction rate expressions. These two types have the following fields:
       + For `ComplexMatrixNetwork`
 
           * `stoichmat`, the complex stoichiometry matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.complexstoichmat).
+            here](https://docs.sciml.ai/Catalyst/stable/api/network_analysis_api/#Catalyst.complexstoichmat).
           * `incidencemat`, the complex incidence matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.reactioncomplexes).
+            here](https://docs.sciml.ai/Catalyst/stable/api/network_analysis_api/#Catalyst.reactioncomplexes).
   - `species`, an optional vector of symbolic variables representing each species
     in the network. Can be constructed using the Catalyst.jl `@species` macro.
     Each species should be dependent on the same time variable (`t` in the example

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ rn = loadrxnetwork(cmn::ComplexMatrixNetwork)
 Here `MatrixNetwork` and `ComplexMatrixNetwork` are the types, which select that
 we are constructing a substrate/product stoichiometric matrix-based or a
 reaction complex matrix-based stoichiometric representation as input. See the
-[Catalyst.jl API](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/) for more
+[Catalyst.jl API](https://docs.sciml.ai/Catalyst/stable/api/core_api/) for more
 discussion on these matrix representations, and how Catalyst handles symbolic
 reaction rate expressions. These two types have the following fields:
 
@@ -181,9 +181,9 @@ reaction rate expressions. These two types have the following fields:
       + For `ComplexMatrixNetwork`
 
           * `stoichmat`, the complex stoichiometry matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.complexstoichmat).
+            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.complexstoichmat).
           * `incidencemat`, the complex incidence matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.reactioncomplexes).
+            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.reactioncomplexes).
   - `species`, an optional vector of symbolic variables representing each species
     in the network. Can be constructed using the Catalyst.jl `@species` macro.
     Each species should be dependent on the same time variable (`t` in the example

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ReactionNetworkImporters = "b4db0fb7-de2a-5028-82bf-5021f5cfa881"
 
 [compat]
-Catalyst = "15.0"
+Catalyst = "16"
 Documenter = "1"
-ReactionNetworkImporters = "0.16"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,7 +55,7 @@ description, i.e. a
 file, which can be loaded into a Catalyst `ReactionSystem` as:
 
 ```julia
-using ReactionNetworkImporters
+using ReactionNetworkImporters, Catalyst
 fname = "PATH/TO/Repressilator.net"
 rn = loadrxnetwork(BNGNetwork(), fname)
 ```
@@ -82,7 +82,7 @@ Given the loaded `ReactionSystem`, we can construct and solve the corresponding
 ODE model by
 
 ```julia
-using OrdinaryDiffEq, Catalyst
+using OrdinaryDiffEqTsit5
 rn = complete(rn)   # mark the reaction network as complete
 tf = 100000.0
 oprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
@@ -107,6 +107,8 @@ network using the `@reaction_network` macro, and then show how to build the same
 network from these matrices using `ReactionNetworkImporters`:
 
 ```julia
+using ReactionNetworkImporters, Catalyst
+
 # Catalyst network from the macro:
 rs = @reaction_network testnetwork begin
     k1, 2A --> B
@@ -133,8 +135,7 @@ mn = MatrixNetwork(pars, substoich, prodstoich; species = species,
 rn = loadrxnetwork(mn; name = :testnetwork) # dense version
 
 # test the two networks are the same
-using Catalyst: isequivalent
-@assert isequivalent(rs, complete(rn))
+@assert Catalyst.isequivalent(rs, complete(rn))
 
 # network from reaction complex stoichiometry
 stoichmat = [2 0 1 0 0 3;
@@ -151,7 +152,7 @@ cmn = ComplexMatrixNetwork(pars, stoichmat, incidencemat; species = species,
 rn = loadrxnetwork(cmn; name = :testnetwork)
 
 # test the two networks are the same
-@assert isequivalent(rs, complete(rn))
+@assert Catalyst.isequivalent(rs, complete(rn))
 ```
 
 The basic usages are

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 This package provides importers to load reaction networks into
 [Catalyst.jl](https://docs.sciml.ai/Catalyst/stable/)
-[`ReactionSystem`s](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.ReactionSystem)
+[`ReactionSystem`s](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.ReactionSystem)
 from several file formats. Currently, it supports loading networks in the
 following formats:
 
@@ -169,7 +169,7 @@ rn = loadrxnetwork(cmn::ComplexMatrixNetwork)
 Here `MatrixNetwork` and `ComplexMatrixNetwork` are the types, which select that
 we are constructing a substrate/product stoichiometric matrix-based or a
 reaction complex matrix-based stoichiometric representation as input. See the
-[Catalyst.jl API](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/) for more
+[Catalyst.jl API](https://docs.sciml.ai/Catalyst/stable/api/core_api/) for more
 discussion on these matrix representations, and how Catalyst handles symbolic
 reaction rate expressions. These two types have the following fields:
 
@@ -193,9 +193,9 @@ reaction rate expressions. These two types have the following fields:
       + For `ComplexMatrixNetwork`
 
           * `stoichmat`, the complex stoichiometry matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.complexstoichmat).
+            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.complexstoichmat).
           * `incidencemat`, the complex incidence matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.reactioncomplexes).
+            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.reactioncomplexes).
   - `species`, an optional vector of symbolic variables representing each species
     in the network. Can be constructed using the Catalyst.jl `@species` macro.
     Each species should be dependent on the same time variable (`t` in the example

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 This package provides importers to load reaction networks into
 [Catalyst.jl](https://docs.sciml.ai/Catalyst/stable/)
-[`ReactionSystem`s](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#ModelingToolkit.ReactionSystem)
+[`ReactionSystem`s](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.ReactionSystem)
 from several file formats. Currently, it supports loading networks in the
 following formats:
 
@@ -35,7 +35,7 @@ Pkg.add("ReactionNetworkImporters")
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.
   - There are a few community forums:
-    
+
       + The #diffeq-bridged and #sciml-bridged channels in the
         [Julia Slack](https://julialang.org/slack/)
       + The #diffeq-bridged and #sciml-bridged channels in the
@@ -57,44 +57,40 @@ file, which can be loaded into a Catalyst `ReactionSystem` as:
 ```julia
 using ReactionNetworkImporters
 fname = "PATH/TO/Repressilator.net"
-prnbng = loadrxnetwork(BNGNetwork(), fname)
+rn = loadrxnetwork(BNGNetwork(), fname)
 ```
 
 Here `BNGNetwork` is a type specifying the file format that is being loaded.
-`prnbng` is a `ParsedReactionNetwork` structure with the following fields:
+`loadrxnetwork` returns a Catalyst `ReactionSystem` (**not** marked as complete
+by default). Initial conditions, parameter values, and BNG-specific mappings are
+stored as system metadata and can be accessed via:
 
-  - `rn`, a Catalyst `ReactionSystem`. **Note** this system is *not* marked
-    complete by default (see the [Catalyst docs](https://catalyst.sciml.ai/) for
-    a discussion of completeness of systems).
-  - `u0`, a `Dict` mapping initial condition symbolic variables to numeric values
-    and/or symbolic expressions.
-  - `p`, a `Dict` mapping parameter symbolic variables to numeric values and/or
-    symbolic expressions.
-  - `varstonames`, a `Dict` mapping the internal symbolic variable of a species
-    used in the generated `ReactionSystem` to a `String` generated from the name
-    in the .net file. This is necessary as BioNetGen can generate exceptionally
-    long species names, involving characters that lead to malformed species names
-    when used with `Catalyst`.
-  - `groupstosyms`, a `Dict` mapping the `String`s representing names for any
-    groups defined in the BioNetGen file to the corresponding symbolic variable
-    representing the `ModelingToolkit` symbolic observable associated with the
-    group.
+  - `Catalyst.get_u0_map(rn)`, a `Dict` mapping initial condition symbolic
+    variables to numeric values and/or symbolic expressions.
+  - `Catalyst.get_parameter_map(rn)`, a `Dict` mapping parameter symbolic
+    variables to numeric values and/or symbolic expressions.
+  - `get_varstonames(rn)`, a `Dict` mapping the internal symbolic variable of a
+    species used in the generated `ReactionSystem` to a `String` generated from
+    the name in the .net file. This is necessary as BioNetGen can generate
+    exceptionally long species names, involving characters that lead to
+    malformed species names when used with `Catalyst`.
+  - `get_groupstosyms(rn)`, a `Dict` mapping the `String`s representing names
+    for any groups defined in the BioNetGen file to the corresponding symbolic
+    variable representing the symbolic observable associated with the group.
 
-Given `prnbng`, we can construct and solve the corresponding ODE model for the
-reaction system by
+Given the loaded `ReactionSystem`, we can construct and solve the corresponding
+ODE model by
 
 ```julia
 using OrdinaryDiffEq, Catalyst
-rn = complete(prnbng.rn)   # get the reaction network and mark it complete
+rn = complete(rn)   # mark the reaction network as complete
 tf = 100000.0
 oprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
 sol = solve(oprob, Tsit5(), saveat = tf / 1000.0)
 ```
 
 Note that we specify empty parameter and initial condition vectors, as these are
-already stored in the generated `ReactionSystem`, `rn`. A `Dict` mapping each
-symbolic species and parameter to its initial value or symbolic expression can
-be obtained using `ModelingToolkit.defaults(rn)`.
+already stored in the generated `ReactionSystem` via `initial_conditions`.
 
 See the [Catalyst documentation](https://docs.sciml.ai/Catalyst/stable/) for how to
 generate ODE, SDE, jump and other types of models.
@@ -134,10 +130,11 @@ prodstoich = [0 2 0 1 3;
               0 0 1 0 0]
 mn = MatrixNetwork(pars, substoich, prodstoich; species = species,
     params = pars) # a matrix network
-prn = loadrxnetwork(mn) # dense version
+rn = loadrxnetwork(mn; name = :testnetwork) # dense version
 
 # test the two networks are the same
-@assert rs == prn.rn
+using Catalyst: isequivalent
+@assert isequivalent(rs, complete(rn))
 
 # network from reaction complex stoichiometry
 stoichmat = [2 0 1 0 0 3;
@@ -151,10 +148,10 @@ incidencemat = [-1 1 0 0 0;
                 0 0 0 0 1]
 cmn = ComplexMatrixNetwork(pars, stoichmat, incidencemat; species = species,
     params = pars)  # a complex matrix network
-prn = loadrxnetwork(cmn; name = :testnetwork)
+rn = loadrxnetwork(cmn; name = :testnetwork)
 
 # test the two networks are the same
-@assert rs == prn.rn
+@assert isequivalent(rs, complete(rn))
 ```
 
 The basic usages are
@@ -162,11 +159,11 @@ The basic usages are
 ```julia
 mn = MatrixNetwork(rateexprs, substoich, prodstoich; species = Any[],
     params = Any[], t = nothing)
-prn = loadrxnetwork(mn::MatrixNetwork)
+rn = loadrxnetwork(mn::MatrixNetwork)
 
 cmn = ComplexMatrixNetwork(rateexprs, stoichmat, incidencemat; species = Any[],
     params = Any[], t = nothing)
-prn = loadrxnetwork(cmn::ComplexMatrixNetwork)
+rn = loadrxnetwork(cmn::ComplexMatrixNetwork)
 ```
 
 Here `MatrixNetwork` and `ComplexMatrixNetwork` are the types, which select that
@@ -183,18 +180,18 @@ reaction rate expressions. These two types have the following fields:
     involving parameters and species like `k*A`.
 
   - matrix inputs
-    
+
       + For `MatrixNetwork`
-        
+
           * `substoich`, a number of species by number of reactions matrix, with entry
             `(i,j)` giving the stoichiometric coefficient of species `i` as a
             substrate in reaction `j`.
           * `prodstoich`, a number of species by number of reactions matrix, with entry
             `(i,j)` giving the stoichiometric coefficient of species `i` as a product
             in reaction `j`.
-    
+
       + For `ComplexMatrixNetwork`
-        
+
           * `stoichmat`, the complex stoichiometry matrix [defined
             here](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.complexstoichmat).
           * `incidencemat`, the complex incidence matrix [defined
@@ -204,20 +201,16 @@ reaction rate expressions. These two types have the following fields:
     Each species should be dependent on the same time variable (`t` in the example
     above).
   - `parameters`, a vector of symbolic variables representing each parameter in
-    the network. Can be constructed with the
-    [ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/)
-    `@parameters` macro. If no parameters are used, it is an optional keyword.
+    the network. Can be constructed with the Catalyst.jl `@parameters` macro. If
+    no parameters are used, it is an optional keyword.
   - `t`, an optional Symbolics.jl variable representing time as the independent
     variable of the reaction network. If not provided, `Catalyst.default_t()` is
     used to determine the default time variable.
 
-For both input types, `loadrxnetwork` returns a `ParsedReactionNetwork`, `prn`,
-with only the field, `prn.rn`, filled in. `prn.rn` corresponds to the generated
-[Catalyst.jl
-`ReactionSystem`](https://docs.sciml.ai/Catalyst/stable/api/catalyst_api/#Catalyst.ReactionSystem)
-that represents the network. **Note**, `prn.rn` is not marked as complete by
-default and must be manually completed by setting `rn = complete(prn.rn)` before
-creating an `ODEProblem` or such, see the Catalyst docs for details.
+For both input types, `loadrxnetwork` returns a Catalyst `ReactionSystem`. The
+system is **not** marked as complete by default and must be manually completed by
+calling `rn = complete(rn)` before creating an `ODEProblem` or such; see the
+Catalyst docs for details.
 
 Dispatches are added if `substoich` and `prodstoich` both have the type
 `SparseMatrixCSC`in case of `MatrixNetwork` (or `stoichmat` and `incidencemat`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -193,9 +193,9 @@ reaction rate expressions. These two types have the following fields:
       + For `ComplexMatrixNetwork`
 
           * `stoichmat`, the complex stoichiometry matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.complexstoichmat).
+            here](https://docs.sciml.ai/Catalyst/stable/api/network_analysis_api/#Catalyst.complexstoichmat).
           * `incidencemat`, the complex incidence matrix [defined
-            here](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.reactioncomplexes).
+            here](https://docs.sciml.ai/Catalyst/stable/api/network_analysis_api/#Catalyst.reactioncomplexes).
   - `species`, an optional vector of symbolic variables representing each species
     in the network. Can be constructed using the Catalyst.jl `@species` macro.
     Each species should be dependent on the same time variable (`t` in the example

--- a/examples/bcrssa_bench.jl
+++ b/examples/bcrssa_bench.jl
@@ -7,10 +7,21 @@ fname = joinpath(datadir, "BCRSSA.net")
 rn = loadrxnetwork(BNGNetwork(), fname)
 rn = complete(rn)
 
+# tequil   = 30000.0
+# u0 = [s => Int(v) for (s, v) in pairs(Catalyst.get_u0_map(rn))]
+# jprob = JumpProblem(rn, u0, (0.0, tequil), []; save_positions = (false, false))
+
+# # try solving as a test
+# sol = solve(jprob, SSAStepper(), saveat = tequil / 1000)
+
+# @unpack Activated_Syk = rn
+# plot(sol, idxs = Activated_Syk)
+
 # post equilibration solve
 tf = 20000.0
 u0 = [s => Int(v) for (s, v) in pairs(Catalyst.get_u0_map(rn))]
 jprob = JumpProblem(rn, u0, (0.0, tf), []; save_positions = (false, false))
+@assert eltype(jprob.prob.u0) <: Int
 sol = solve(jprob, SSAStepper(), saveat = tf / 20000)
 @unpack Activated_Syk = rn
 plot(sol, idxs = Activated_Syk)

--- a/examples/bcrssa_bench.jl
+++ b/examples/bcrssa_bench.jl
@@ -1,39 +1,16 @@
-using ReactionNetworkImporters, Catalyst, ModelingToolkit, DiffEqJump
+using ReactionNetworkImporters, Catalyst, JumpProcesses
 using Plots
 
 datadir = joinpath(@__DIR__, "../data/bcr_ssa")
 fname = joinpath(datadir, "BCRSSA.net")
 
-prn = loadrxnetwork(BNGNetwork(), fname)
-rn = prn.rn
-
-# tequil   = 30000.0
-# jsys = convert(JumpSystem, rn)
-# defs = ModelingToolkit.defaults(rn)
-# u0 = convert.(Int, ModelingToolkit.varmap_to_vars(ModelingToolkit.defaults(jsys), states(jsys)))
-# dprob = DiscreteProblem(jsys, u0, (0.0,tequil), [])
-# @assert eltype(dprob.u0) <: Int
-# jprob = JumpProblem(jsys, dprob, RSSACR(), save_positions=(false,false))
-
-# # try solving as a test
-# sol = solve(jprob, SSAStepper(), saveat=tequil/1000)
-
-# @unpack Activated_Syk = rn
-# plot(sol, vars=Activated_Syk)
-
-# u0 = sol[end]
-# setdefaults!(rn, [:c => 3.0])
+rn = loadrxnetwork(BNGNetwork(), fname)
+rn = complete(rn)
 
 # post equilibration solve
 tf = 20000.0
-jsys = convert(JumpSystem, rn)
-u0 = convert.(
-    Int,
-    ModelingToolkit.varmap_to_vars(ModelingToolkit.defaults(jsys), states(jsys))
-)
-dprob = DiscreteProblem(jsys, u0, (0.0, tf), [])
-@assert eltype(dprob.u0) <: Int
-jprob = JumpProblem(jsys, dprob, RSSACR(), save_positions = (false, false))
+u0 = [s => Int(v) for (s, v) in pairs(Catalyst.get_u0_map(rn))]
+jprob = JumpProblem(rn, u0, (0.0, tf), []; save_positions = (false, false))
 sol = solve(jprob, SSAStepper(), saveat = tf / 20000)
 @unpack Activated_Syk = rn
-plot(sol, vars = Activated_Syk)
+plot(sol, idxs = Activated_Syk)

--- a/examples/test_bcr_odes.jl
+++ b/examples/test_bcr_odes.jl
@@ -31,10 +31,10 @@ const to = TimerOutput()
 reset_timer!(to)
 
 # BioNetGen network
-@timeit to "bionetgen" prnbng = loadrxnetwork(BNGNetwork(), fname);
+@timeit to "bionetgen" rnbng = loadrxnetwork(BNGNetwork(), fname);
 show(to)
-rnbng = prnbng.rn
-@timeit to "bODESystem" bosys = convert(ODESystem, rnbng)
+rnbng = complete(rnbng)
+@timeit to "bODESystem" bosys = ode_model(rnbng)
 show(to)
 @timeit to "bODEProb" boprob = ODEProblem(bosys, Float64[], (0.0, tf), Float64[])
 show(to)
@@ -43,24 +43,10 @@ p = zeros(length(parameters(rnbng)))
 du = similar(u);
 @timeit to "f1" boprob.f(du, u, p, 0.0)
 @timeit to "f2" boprob.f(du, u, p, 0.0)
-if build_jac
-    J = zeros(length(u), length(u))
-    #J = similar(rnbng.odefun.jac_prototype)
-    @timeit to "J1" rnbng.jac(J, u, p, 0.0)
-    @timeit to "J2" rnbng.jac(J, u, p, 0.0)
-end
 show(to)
 println()
 
 # DiffEq solver
-#reset_timer!(to);
-#@timeit to "BNG_CVODE_BDF-LU-1" begin bsol = solve(boprob, CVODE_BDF(), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
-#@timeit to "BNG_CVODE_BDF-LU-2" begin bsol = solve(boprob, CVODE_BDF(), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
-#@timeit to "BNG_CVODE_BDF-GMRES-1" begin bsol = solve(boprob, CVODE_BDF(linear_solver=:GMRES), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
-#@timeit to "BNG_CVODE_BDF-GMRES-2" begin bsol = solve(boprob, CVODE_BDF(linear_solver=:GMRES), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
-# #reset_timer!(to); @timeit to "BNG_RODAS5_BDF" begin bsol2 = solve(boprob, rodas5(autodiff=false), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
-#@timeit to "KenCarp4-1" begin sol = solve(boprob,KenCarp4(autodiff=false,linsolve=LinSolveFactorize(lu)), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
-#@timeit to "KenCarp4-2" begin bsol = solve(boprob,KenCarp4(autodiff=false,linsolve=LinSolveFactorize(lu)), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
 @timeit to "KenCarp4-1" begin
     sol = solve(
         boprob, KenCarp4(autodiff = false), abstol = 1.0e-8,
@@ -92,8 +78,4 @@ if doplot
 end
 
 # test the error, note may be large in abs value though small relatively
-# #norm(gdatdf[:Activated_Syk] - asynbng, Inf)
-# #norm(asynbng - basyk', Inf)
 norm(gdatdf[!, :Activated_Syk] - sol[Activated_Syk], Inf)
-
-#@assert all(abs.(gdatdf[!,:Activated_Syk] - basyk') .< 1e-6 * abs.(gdatdf[:Activated_Syk]))

--- a/examples/test_bcr_odes.jl
+++ b/examples/test_bcr_odes.jl
@@ -43,10 +43,24 @@ p = zeros(length(parameters(rnbng)))
 du = similar(u);
 @timeit to "f1" boprob.f(du, u, p, 0.0)
 @timeit to "f2" boprob.f(du, u, p, 0.0)
+if build_jac
+    J = zeros(length(u), length(u))
+    #J = similar(rnbng.odefun.jac_prototype)
+    @timeit to "J1" rnbng.jac(J, u, p, 0.0)
+    @timeit to "J2" rnbng.jac(J, u, p, 0.0)
+end
 show(to)
 println()
 
 # DiffEq solver
+#reset_timer!(to);
+#@timeit to "BNG_CVODE_BDF-LU-1" begin bsol = solve(boprob, CVODE_BDF(), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
+#@timeit to "BNG_CVODE_BDF-LU-2" begin bsol = solve(boprob, CVODE_BDF(), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
+#@timeit to "BNG_CVODE_BDF-GMRES-1" begin bsol = solve(boprob, CVODE_BDF(linear_solver=:GMRES), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
+#@timeit to "BNG_CVODE_BDF-GMRES-2" begin bsol = solve(boprob, CVODE_BDF(linear_solver=:GMRES), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
+# #reset_timer!(to); @timeit to "BNG_RODAS5_BDF" begin bsol2 = solve(boprob, rodas5(autodiff=false), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
+#@timeit to "KenCarp4-1" begin sol = solve(boprob,KenCarp4(autodiff=false,linsolve=LinSolveFactorize(lu)), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
+#@timeit to "KenCarp4-2" begin bsol = solve(boprob,KenCarp4(autodiff=false,linsolve=LinSolveFactorize(lu)), saveat=1., abstol=1e-8, reltol=1e-8); end; show(to)
 @timeit to "KenCarp4-1" begin
     sol = solve(
         boprob, KenCarp4(autodiff = false), abstol = 1.0e-8,
@@ -78,4 +92,8 @@ if doplot
 end
 
 # test the error, note may be large in abs value though small relatively
+# #norm(gdatdf[:Activated_Syk] - asynbng, Inf)
+# #norm(asynbng - basyk', Inf)
 norm(gdatdf[!, :Activated_Syk] - sol[Activated_Syk], Inf)
+
+#@assert all(abs.(gdatdf[!,:Activated_Syk] - basyk') .< 1e-6 * abs.(gdatdf[:Activated_Syk]))

--- a/src/ReactionNetworkImporters.jl
+++ b/src/ReactionNetworkImporters.jl
@@ -2,6 +2,7 @@ module ReactionNetworkImporters
 
 using DataStructures, Catalyst, SparseArrays
 using Symbolics: operation, unwrap
+using SymbolicUtils: hasmetadata, getmetadata, setmetadata
 
 # creates a ModelingToolkit function-like Symbol
 # can then do stuff like
@@ -19,78 +20,85 @@ abstract type NetworkFileFormat end
 #struct RSSANetwork <: NetworkFileFormat end
 struct BNGNetwork <: NetworkFileFormat end
 
+### System-Level Metadata Key Types and Accessors ###
+
 """
-    ParsedReactionNetwork(rn::ReactionSystem; u0 = nothing, p = nothing, varstonames = nothing, groupstosyms = nothing)
+    VarsToNames
 
-A container for storing a parsed reaction network along with its associated metadata.
+Metadata key for storing BNG species variable-to-full-name mappings on a
+`ReactionSystem`. Stores a `Dict` mapping the internal symbolic variable of a
+species to a `String` with its full name from the .net file.
 
-# Fields
-- `rn`, a Catalyst `ReactionSystem`. **Note** this system is *not* marked complete by
-  default (see the [Catalyst docs](https://catalyst.sciml.ai/) for a discussion of
-  completeness of systems).
-- `u0`, a `Dict` mapping initial condition symbolic variables to numeric values and/or
-  symbolic expressions.
-- `p`, a `Dict` mapping parameter symbolic variables to numeric values and/or symbolic
-  expressions.
-- `varstonames`, a `Dict` mapping the internal symbolic variable of a species used in the
-  generated `ReactionSystem` to a `String` generated from the name in the .net file. This is
-  necessary as BioNetGen can generate exceptionally long species names, involving characters
-  that lead to malformed species names when used with `Catalyst`.
-- `groupstosyms`, a `Dict` mapping the `String`s representing names for any groups defined
-  in the BioNetGen file to the corresponding symbolic variable representing the
-  `ModelingToolkit` symbolic observable associated with the group.
+See also: [`has_varstonames`](@ref), [`get_varstonames`](@ref), [`set_varstonames`](@ref)
 """
-struct ParsedReactionNetwork
-    "Catalyst Network"
-    rn::ReactionSystem
+struct VarsToNames end
 
-    "Dict mapping initial condition symbolic variables to values."
-    u0::Any
+"""
+    has_varstonames(rs::ReactionSystem)
 
-    "Dict mapping parameter symbolic variables to values."
-    p::Any
+Returns `true` if the `ReactionSystem` has a `VarsToNames` metadata entry.
+"""
+has_varstonames(rs::ReactionSystem) = hasmetadata(rs, VarsToNames)
 
-    "Dict mapping symbolic variable for species names to full string for species name"
-    varstonames::Any
+"""
+    get_varstonames(rs::ReactionSystem)
 
-    "Dict from group name (as string) to corresponding symbolic variable"
-    groupstosyms::Any
-end
-function ParsedReactionNetwork(
-        rn::ReactionSystem; u0 = nothing, p = nothing,
-        varstonames = nothing, groupstosyms = nothing
-    )
-    return ParsedReactionNetwork(rn, u0, p, varstonames, groupstosyms)
-end
+Returns the `VarsToNames` metadata from the `ReactionSystem`, or `nothing` if
+not set.
+"""
+get_varstonames(rs::ReactionSystem) = getmetadata(rs, VarsToNames, nothing)
 
-export BNGNetwork, MatrixNetwork, ParsedReactionNetwork, ComplexMatrixNetwork
+"""
+    set_varstonames(rs::ReactionSystem, m)
+
+Returns a **new** `ReactionSystem` with the `VarsToNames` metadata set to `m`.
+The original system is not modified.
+"""
+set_varstonames(rs::ReactionSystem, m) = setmetadata(rs, VarsToNames, m)
+
+"""
+    GroupsToSyms
+
+Metadata key for storing BNG group-name-to-symbol mappings on a
+`ReactionSystem`. Stores a `Dict` mapping `String` group names to
+corresponding symbolic observable variables.
+
+See also: [`has_groupstosyms`](@ref), [`get_groupstosyms`](@ref), [`set_groupstosyms`](@ref)
+"""
+struct GroupsToSyms end
+
+"""
+    has_groupstosyms(rs::ReactionSystem)
+
+Returns `true` if the `ReactionSystem` has a `GroupsToSyms` metadata entry.
+"""
+has_groupstosyms(rs::ReactionSystem) = hasmetadata(rs, GroupsToSyms)
+
+"""
+    get_groupstosyms(rs::ReactionSystem)
+
+Returns the `GroupsToSyms` metadata from the `ReactionSystem`, or `nothing` if
+not set.
+"""
+get_groupstosyms(rs::ReactionSystem) = getmetadata(rs, GroupsToSyms, nothing)
+
+"""
+    set_groupstosyms(rs::ReactionSystem, m)
+
+Returns a **new** `ReactionSystem` with the `GroupsToSyms` metadata set to `m`.
+The original system is not modified.
+"""
+set_groupstosyms(rs::ReactionSystem, m) = setmetadata(rs, GroupsToSyms, m)
+
+export BNGNetwork, MatrixNetwork, ComplexMatrixNetwork
+export VarsToNames, GroupsToSyms
+export has_varstonames, get_varstonames, set_varstonames
+export has_groupstosyms, get_groupstosyms, set_groupstosyms
 
 # parsers
 include("parsing_routines_bngnetworkfiles.jl")
 include("parsing_routines_matrixnetworks.jl")
 
 export loadrxnetwork
-
-# Overload ensuring that u0 and u₀ can be used interchangeably.
-# (introduced when the u₀ field was changed to u0)
-# Should be deleted whenever u₀ is fully deprecated.
-
-# Ensures that `prnbng.u₀` works.
-function Base.getproperty(prnbng::ParsedReactionNetwork, name::Symbol)
-    if name === :u₀
-        return getfield(prnbng, :u0)
-    else
-        return getfield(prnbng, name)
-    end
-end
-
-# Ensures that `prnbng.u₀ = ...` works.
-function Base.setproperty!(prnbng::ParsedReactionNetwork, name::Symbol, x)
-    if name === :u₀
-        return setfield!(prnbng, :u0, x)
-    else
-        return setfield!(prnbng, name, x)
-    end
-end
 
 end # module

--- a/src/parsing_routines_bngnetworkfiles.jl
+++ b/src/parsing_routines_bngnetworkfiles.jl
@@ -228,9 +228,9 @@ end
 
 # for parsing a subset of the BioNetGen .net file format
 """
-    loadrxnetwork(ft::BNGNetwork, rxfilename; name = gensym(:ReactionSystem), verbose = false, kwargs...)
+    loadrxnetwork(ft::BNGNetwork, rxfilename; name = gensym(:ReactionSystem), verbose = true, kwargs...)
 
-Parses a BioNetGen `.net` file and constructs a `ParsedReactionNetwork` object.
+Parses a BioNetGen `.net` file and constructs a Catalyst `ReactionSystem`.
 
 # Arguments
 - `ft::BNGNetwork`: Indicates the file to be parsed is a BioNetGen ".net" file.
@@ -242,10 +242,12 @@ Parses a BioNetGen `.net` file and constructs a `ParsedReactionNetwork` object.
 - `kwargs...`: Additional keyword arguments passed to the `ReactionSystem` constructor.
 
 # Returns
-A `ParsedReactionNetwork` object containing:
-- The `ReactionSystem` with reactions, species, and parameters.
-- Initial conditions (`u0`) and parameter values (`p`).
-- Mappings between variable names and symbols.
+A Catalyst `ReactionSystem` (not marked as complete). Initial conditions, parameter
+values, and BNG-specific mappings are stored as system metadata:
+- `Catalyst.get_u0_map(rn)`: `Dict` mapping species to initial condition values.
+- `Catalyst.get_parameter_map(rn)`: `Dict` mapping parameters to their values.
+- `get_varstonames(rn)`: `Dict` mapping internal species symbols to full BNG name strings.
+- `get_groupstosyms(rn)`: `Dict` mapping BNG group name strings to observable symbols.
 
 # Notes
 This function parses a subset of the BioNetGen `.net` file format. It assumes:
@@ -255,7 +257,8 @@ This function parses a subset of the BioNetGen `.net` file format. It assumes:
 
 # Example
 ```julia
-parsed_network = loadrxnetwork(BNGNetwork(), "path/to/network.net", verbose = true)
+rn = loadrxnetwork(BNGNetwork(), "path/to/network.net", verbose = true)
+rn = complete(rn)
 ```
 """
 function loadrxnetwork(
@@ -320,20 +323,20 @@ function loadrxnetwork(
     close(file)
 
     # setup default values / expressions for params and initial conditions
-    defmap, pmap, u0map = exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs, ps)
+    _, pmap, u0map = exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs, ps)
 
-    # build the model
+    # build the model with metadata
+    metadata = [Catalyst.U0Map => u0map, Catalyst.ParameterMap => pmap,
+        VarsToNames => shortsymstosyms, GroupsToSyms => groupstosyms]
     rn = ReactionSystem(
-        rxs, t, specs, ps; name = name, observed = obseqs,
-        defaults = defmap, kwargs...
+        rxs, t, specs, ps; name, observed = obseqs,
+        initial_conditions = merge(u0map, pmap),
+        metadata, kwargs...
     )
 
-    # get numeric values for parameters and u0
+    # verify species ordering
     sm = speciesmap(rn)
     @assert all(sm[funcsym(sym, t)] == i for (i, sym) in enumerate(idstoshortsyms))
 
-    return ParsedReactionNetwork(
-        rn; u0 = u0map, p = pmap, varstonames = shortsymstosyms,
-        groupstosyms = groupstosyms
-    )
+    return rn
 end

--- a/src/parsing_routines_bngnetworkfiles.jl
+++ b/src/parsing_routines_bngnetworkfiles.jl
@@ -323,14 +323,14 @@ function loadrxnetwork(
     close(file)
 
     # setup default values / expressions for params and initial conditions
-    _, pmap, u0map = exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs, ps)
+    defmap, pmap, u0map = exprs_to_defs(opmod, ptoids, pvals, specs, u0exprs, ps)
 
     # build the model with metadata
     metadata = [Catalyst.U0Map => u0map, Catalyst.ParameterMap => pmap,
         VarsToNames => shortsymstosyms, GroupsToSyms => groupstosyms]
     rn = ReactionSystem(
         rxs, t, specs, ps; name, observed = obseqs,
-        initial_conditions = merge(u0map, pmap),
+        initial_conditions = defmap,
         metadata, kwargs...
     )
 

--- a/src/parsing_routines_matrixnetworks.jl
+++ b/src/parsing_routines_matrixnetworks.jl
@@ -37,8 +37,7 @@ end
 """
     loadrxnetwork(mn::MatrixNetwork; name = gensym(:ReactionSystem))
 
-Converts a `MatrixNetwork` into a `ParsedReactionNetwork` by constructing a
-`ReactionSystem`.
+Converts a `MatrixNetwork` into a Catalyst `ReactionSystem`.
 
 # Arguments
 - `mn::MatrixNetwork`: A `MatrixNetwork` object containing the stoichiometric matrices, rate
@@ -47,7 +46,7 @@ Converts a `MatrixNetwork` into a `ParsedReactionNetwork` by constructing a
   generated symbol.
 
 # Returns
-A `ParsedReactionNetwork` 
+A Catalyst `ReactionSystem` (not marked as complete).
 
 # Notes
 - The `MatrixNetwork` must have substrate (`substoich`) and product (`prodstoich`)
@@ -71,8 +70,8 @@ species = [@species A(t), B(t)]
 params = [@parameters k1, k2]
 mn = MatrixNetwork(rateexprs, substoich, prodstoich; species = species, params = params)
 
-# Convert to a ParsedReactionNetwork
-parsed_network = loadrxnetwork(mn, name = :MyReactionSystem)
+# Convert to a ReactionSystem
+rn = loadrxnetwork(mn, name = :MyReactionSystem)
 ```
 """
 function loadrxnetwork(
@@ -120,7 +119,7 @@ function loadrxnetwork(
         rxs[j] = Reaction(mn.rateexprs[j], subs, prods, sstoich, pstoich)
     end
 
-    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, mn.params; name = name))
+    return ReactionSystem(rxs, t, species, mn.params; name)
 end
 
 # for sparse matrices
@@ -176,7 +175,7 @@ function loadrxnetwork(
         rxs[j] = Reaction(mn.rateexprs[j], subs, prods, sstoich, pstoich)
     end
 
-    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, mn.params; name = name))
+    return ReactionSystem(rxs, t, species, mn.params; name)
 end
 
 """
@@ -273,7 +272,7 @@ function loadrxnetwork(
         end
     end
 
-    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, cmn.params; name = name))
+    return ReactionSystem(rxs, t, species, cmn.params; name)
 end
 
 # for sparse matrices version
@@ -328,5 +327,5 @@ function loadrxnetwork(
         end
     end
 
-    return ParsedReactionNetwork(ReactionSystem(rxs, t, species, cmn.params; name = name))
+    return ReactionSystem(rxs, t, species, cmn.params; name)
 end

--- a/test/test_higherorder_odes.jl
+++ b/test/test_higherorder_odes.jl
@@ -36,5 +36,13 @@ Asol = gdatdf[!, :A]
 # note solvers run _much_ faster the second time
 bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps);
 
+# if doplot
+#     plotlyjs()
+#     p1 = plot(gdatdf[!, :time], gdatdf[!, :A], label = :A_BNG)
+#     plot!(p1, bsol.t, bsol[A], label = :A_DE)
+#     display(p1)
+#     println("Err = ", norm(gdatdf[!, :A] - bsol[Aid, :], Inf))
+# end
+
 @test all(bsol.t .== gdatdf[!, :time])
 @test all(abs.(gdatdf[!, :A] - bsol[A]) .< 1.0e-6 .* abs.(gdatdf[!, :A]))

--- a/test/test_higherorder_odes.jl
+++ b/test/test_higherorder_odes.jl
@@ -1,6 +1,5 @@
-using Catalyst, OrdinaryDiffEqTsit5, DataFrames, CSVFiles, LinearAlgebra
+using Catalyst, OrdinaryDiffEqTsit5, DataFrames, CSV, LinearAlgebra
 using ReactionNetworkImporters
-# using Plots
 
 # parameters
 doplot = false
@@ -13,21 +12,20 @@ datadir = joinpath(@__DIR__, "../data/higherorder")
 fname = joinpath(datadir, "higherorder.net")
 gdatfile = joinpath(datadir, "higherorder.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(
-    load(
-        File{format"CSV"}(gdatfile), header_exists = true,
-        spacedelim = true
-    )
-)
+gdatdf = CSV.read(gdatfile, DataFrame; delim = ' ', ignorerepeated = true)
 println("done")
 
-# load the BNG reaction network in DiffEqBio
-prnbng = loadrxnetwork(BNGNetwork(), fname)
-rn = complete(prnbng.rn)
-boprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
+# load the BNG reaction network
+rnbng = loadrxnetwork(BNGNetwork(), fname)
 
-# Test that u0 == u₀ (used when the u0 indexing was introduced).
-@test isequal(prnbng.u0, prnbng.u₀)
+# test metadata is set
+@test Catalyst.has_u0_map(rnbng)
+@test Catalyst.has_parameter_map(rnbng)
+@test has_varstonames(rnbng)
+@test has_groupstosyms(rnbng)
+
+rn = complete(rnbng)
+boprob = ODEProblem(rn, Float64[], (0.0, tf), Float64[])
 
 @show observed(rn)
 
@@ -37,14 +35,6 @@ Asol = gdatdf[!, :A]
 
 # note solvers run _much_ faster the second time
 bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps);
-
-# if doplot
-#     plotlyjs()
-#     p1 = plot(gdatdf[!, :time], gdatdf[!, :A], label = :A_BNG)
-#     plot!(p1, bsol.t, bsol[A], label = :A_DE)
-#     display(p1)
-#     println("Err = ", norm(gdatdf[!, :A] - bsol[Aid, :], Inf))
-# end
 
 @test all(bsol.t .== gdatdf[!, :time])
 @test all(abs.(gdatdf[!, :A] - bsol[A]) .< 1.0e-6 .* abs.(gdatdf[!, :A]))

--- a/test/test_mats.jl
+++ b/test/test_mats.jl
@@ -1,5 +1,5 @@
 using Catalyst, ReactionNetworkImporters, SparseArrays
-using ModelingToolkit: nameof
+using ModelingToolkitBase: nameof
 
 # version giving parameters and rates
 rs = @reaction_network rs1 begin
@@ -36,21 +36,21 @@ incidencemat = [
     0 0 0 0 1
 ]
 mn1 = MatrixNetwork(pars, substoich, prodstoich; params = pars)
-prn = loadrxnetwork(mn1; name = nameof(rs)) # dense version
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(mn1; name = nameof(rs)) # dense version
+@test Catalyst.isequivalent(rs, complete(rn))
 mn2 = MatrixNetwork(pars, sparse(substoich), sparse(prodstoich); params = pars)
-prn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
+@test Catalyst.isequivalent(rs, complete(rn))
 
 cmn1 = ComplexMatrixNetwork(pars, compstoichmat, incidencemat; params = pars)
-prn = loadrxnetwork(cmn1; name = nameof(rs))
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(cmn1; name = nameof(rs))
+@test Catalyst.isequivalent(rs, complete(rn))
 cmn2 = ComplexMatrixNetwork(
     pars, sparse(compstoichmat), sparse(incidencemat);
     params = pars
 )
-prn = loadrxnetwork(cmn2; name = nameof(rs))
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(cmn2; name = nameof(rs))
+@test Catalyst.isequivalent(rs, complete(rn))
 
 # version with hard coded rates (no parameter symbols)
 rs = @reaction_network rs2 begin
@@ -61,21 +61,21 @@ rs = @reaction_network rs2 begin
     5.0, 3S3 --> 3S1
 end
 mn1 = MatrixNetwork(convert.(Float64, 1:5), substoich, prodstoich)
-prn = loadrxnetwork(mn1; name = nameof(rs))   # dense version
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(mn1; name = nameof(rs))   # dense version
+@test Catalyst.isequivalent(rs, complete(rn))
 mn2 = MatrixNetwork(convert.(Float64, 1:5), sparse(substoich), sparse(prodstoich))
-prn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
+@test Catalyst.isequivalent(rs, complete(rn))
 
 cmn1 = ComplexMatrixNetwork(convert.(Float64, 1:5), compstoichmat, incidencemat)
-prn = loadrxnetwork(cmn1; name = nameof(rs))
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(cmn1; name = nameof(rs))
+@test Catalyst.isequivalent(rs, complete(rn))
 cmn2 = ComplexMatrixNetwork(
     convert.(Float64, 1:5), sparse(compstoichmat),
     sparse(incidencemat)
 )
-prn = loadrxnetwork(cmn2; name = nameof(rs))
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(cmn2; name = nameof(rs))
+@test Catalyst.isequivalent(rs, complete(rn))
 
 # version with species names, rate functions and symbolic parameters
 rs = @reaction_network rs3 begin
@@ -89,25 +89,25 @@ end
 @species A(t) B(t) C(t)
 species = [A, B, C]
 rates = [k1 * A, k2, k3, k4, k5]
-mn1 = MatrixNetwork(rates, substoich, prodstoich; species = species, params = pars)
-prn = loadrxnetwork(mn1; name = nameof(rs)) # dense version
-@test rs == complete(prn.rn)
+mn1 = MatrixNetwork(rates, substoich, prodstoich; species, params = pars)
+rn = loadrxnetwork(mn1; name = nameof(rs)) # dense version
+@test Catalyst.isequivalent(rs, complete(rn))
 mn2 = MatrixNetwork(
-    rates, sparse(substoich), sparse(prodstoich); species = species,
+    rates, sparse(substoich), sparse(prodstoich); species,
     params = pars
 )
-prn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(mn2; name = nameof(rs)) # sparse version
+@test Catalyst.isequivalent(rs, complete(rn))
 
 cmn1 = ComplexMatrixNetwork(
-    rates, compstoichmat, incidencemat; species = species,
+    rates, compstoichmat, incidencemat; species,
     params = pars
 )
-prn = loadrxnetwork(cmn1; name = nameof(rs))
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(cmn1; name = nameof(rs))
+@test Catalyst.isequivalent(rs, complete(rn))
 cmn2 = ComplexMatrixNetwork(
     rates, sparse(compstoichmat), sparse(incidencemat);
-    species = species, params = pars
+    species, params = pars
 )
-prn = loadrxnetwork(cmn2; name = nameof(rs))
-@test rs == complete(prn.rn)
+rn = loadrxnetwork(cmn2; name = nameof(rs))
+@test Catalyst.isequivalent(rs, complete(rn))

--- a/test/test_nullrxs_odes.jl
+++ b/test/test_nullrxs_odes.jl
@@ -1,5 +1,4 @@
-using Catalyst, OrdinaryDiffEqTsit5, DataFrames, CSVFiles, LinearAlgebra
-# using Plots
+using Catalyst, OrdinaryDiffEqTsit5, DataFrames, CSV, LinearAlgebra
 using ReactionNetworkImporters
 
 # parameters
@@ -13,23 +12,22 @@ datadir = joinpath(@__DIR__, "../data/nullrxs")
 fname = joinpath(datadir, "birth-death.net")
 gdatfile = joinpath(datadir, "birth-death.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(
-    load(
-        File{format"CSV"}(gdatfile), header_exists = true,
-        spacedelim = true
-    )
-)
+gdatdf = CSV.read(gdatfile, DataFrame; delim = ' ', ignorerepeated = true)
 println("done")
 
-# load the BNG reaction network in DiffEqBio
-prnbng = loadrxnetwork(BNGNetwork(), fname)
-rn = complete(prnbng.rn)
+# load the BNG reaction network
+rnbng = loadrxnetwork(BNGNetwork(), fname)
+
+# test metadata is set
+@test Catalyst.has_u0_map(rnbng)
+@test Catalyst.has_parameter_map(rnbng)
+@test has_varstonames(rnbng)
+@test has_groupstosyms(rnbng)
+
+rn = complete(rnbng)
 u0 = Float64[]
 p = Float64[]
 boprob = ODEProblem(rn, u0, (0.0, tf), p)
-
-# Test that u0 == u₀ (used when the u0 indexing was introduced).
-@test isequal(prnbng.u0, prnbng.u₀)
 
 # note solvers run _much_ faster the second time
 bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps)

--- a/test/test_repressilator_odes.jl
+++ b/test/test_repressilator_odes.jl
@@ -36,5 +36,12 @@ bngsol = gdatdf[!, :pTetR]
 bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps);
 @unpack pTetR = rn
 
+# if doplot
+#     plotlyjs()
+#     p1 = plot(gdatdf[!, :time], gdatdf[!, :pTetR], label = :BNGPTetR)
+#     plot!(p1, bsol.t, bsol[pTetR], label = :DEBPTetR)
+#     display(p1)
+# end
+
 @test all(bsol.t .== gdatdf[!, :time])
 @test all(abs.(gdatdf[!, :pTetR] - bsol[pTetR]) .< 1.0e-6 .* abs.(gdatdf[!, :pTetR]))

--- a/test/test_repressilator_odes.jl
+++ b/test/test_repressilator_odes.jl
@@ -1,7 +1,5 @@
-using Catalyst, OrdinaryDiffEqTsit5, DataFrames, CSVFiles, LinearAlgebra
+using Catalyst, OrdinaryDiffEqTsit5, DataFrames, CSV, LinearAlgebra
 using ReactionNetworkImporters
-
-# using Plots
 
 # parameters
 doplot = false
@@ -14,23 +12,22 @@ datadir = joinpath(@__DIR__, "../data/repressilator")
 fname = joinpath(datadir, "Repressilator.net")
 gdatfile = joinpath(datadir, "Repressilator.gdat")
 print("getting gdat file...")
-gdatdf = DataFrame(
-    load(
-        File{format"CSV"}(gdatfile), header_exists = true,
-        spacedelim = true
-    )
-)
+gdatdf = CSV.read(gdatfile, DataFrame; delim = ' ', ignorerepeated = true)
 println("done")
 
-# load the BNG reaction network in DiffEqBio
-prnbng = loadrxnetwork(BNGNetwork(), fname)
-rn = complete(prnbng.rn)
+# load the BNG reaction network
+rnbng = loadrxnetwork(BNGNetwork(), fname)
+
+# test metadata is set
+@test Catalyst.has_u0_map(rnbng)
+@test Catalyst.has_parameter_map(rnbng)
+@test has_varstonames(rnbng)
+@test has_groupstosyms(rnbng)
+
+rn = complete(rnbng)
 u0 = Float64[]
 p = Float64[]
 boprob = ODEProblem(rn, u0, (0.0, tf), p)
-
-# Test that u0 == u₀ (used when the u0 indexing was introduced).
-@test isequal(prnbng.u0, prnbng.u₀)
 
 # BNG simulation data testing
 bngsol = gdatdf[!, :pTetR]
@@ -38,13 +35,6 @@ bngsol = gdatdf[!, :pTetR]
 # note solvers run _much_ faster the second time
 bsol = solve(boprob, Tsit5(), abstol = 1.0e-12, reltol = 1.0e-12, saveat = tf / nsteps);
 @unpack pTetR = rn
-
-# if doplot
-#     plotlyjs()
-#     p1 = plot(gdatdf[!, :time], gdatdf[!, :pTetR], label = :BNGPTetR)
-#     plot!(p1, bsol.t, bsol[pTetR], label = :DEBPTetR)
-#     display(p1)
-# end
 
 @test all(bsol.t .== gdatdf[!, :time])
 @test all(abs.(gdatdf[!, :pTetR] - bsol[pTetR]) .< 1.0e-6 .* abs.(gdatdf[!, :pTetR]))


### PR DESCRIPTION
- loadrxnetwork now returns a ReactionSystem directly instead of ParsedReactionNetwork. The ParsedReactionNetwork type is removed.
- Initial conditions and parameter values stored via Catalyst.U0Map and Catalyst.ParameterMap system metadata.
- New VarsToNames and GroupsToSyms metadata types with exported accessors for BNG-specific mappings.
- Replace ModelingToolkit dep with ModelingToolkitBase.
- Add SymbolicUtils dep for metadata functions.
- Replace unmaintained CSVFiles test dep with CSV.jl.
- Update Symbolics compat to v7, Catalyst compat to v16.
- Use Catalyst.isequivalent instead of == for ReactionSystem comparison.
- Use initial_conditions kwarg instead of removed defaults kwarg.
- Update all tests, examples, README, and docs.
- Bump version to 1.0.0.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
