### PR TITLE
Handle OrdinaryDiffEq v7 breaking changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## v1.2.0
+
+- Compat bump for `OrdinaryDiffEqTsit5` to include v2 (the OrdinaryDiffEq v7
+  release line, which brings in SciMLBase v3, DiffEqBase v7, and
+  RecursiveArrayTools v4). No source changes were required.
+
 ## v1.0.0
 
 Breaking release for compatibility with Catalyst.jl v16.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReactionNetworkImporters"
 uuid = "b4db0fb7-de2a-5028-82bf-5021f5cfa881"
-authors = ["Samuel Isaacson <isaacsas@users.noreply.github.com>"]
 version = "1.1.0"
+authors = ["Samuel Isaacson <isaacsas@users.noreply.github.com>"]
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
@@ -21,7 +21,7 @@ DataStructures = "0.18.13, 0.19"
 HypergeometricFunctions = "0.3"
 LinearAlgebra = "1.10"
 ModelingToolkitBase = "1.17"
-OrdinaryDiffEqTsit5 = "1.1"
+OrdinaryDiffEqTsit5 = "1.1, 2"
 SafeTestsets = "0.1"
 SparseArrays = "1.10"
 SymbolicUtils = "4.9.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReactionNetworkImporters"
 uuid = "b4db0fb7-de2a-5028-82bf-5021f5cfa881"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Samuel Isaacson <isaacsas@users.noreply.github.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

Supersedes #164. Same `OrdinaryDiffEqTsit5 = "1.1, 2"` compat widen, plus a version bump (1.1.0 → 1.2.0) and a HISTORY entry pointing at why.

The `OrdinaryDiffEqTsit5` v2 release line is part of OrdinaryDiffEq v7, which brings in **SciMLBase v3**, **DiffEqBase v7**, and **RecursiveArrayTools v4**. See the [v7 NEWS](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md) for the full list of breaking changes.

## No source changes required

I grepped `src/` and `test/` for every symbol the v7 NEWS removes — `u_modified!`, `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`/`intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`, `chunk_size`, `diff_type`, `standardtag`, `qoldinit`, `prob_func(_, i, repeat)` — and got zero matches.

The test suite uses:
- Symbolic indexing (`sol[species(rn_c)[1]][1]`, `sol[getproperty(rn, obs_col)]`) — stable across v3/v4 of RecursiveArrayTools.
- The `ReturnCode.T` enum directly (`sol.retcode == ReturnCode.Success`) — already migrated off the old `Symbol` form.
- Matrix-style indexing (`bsol[1, :]`) — same semantics under both RAT v3 and v4.

## CI note

The CompatHelper job in #164 fails because of `force_latest_compatible_version=true` — it tries to install OrdinaryDiffEqTsit5 v2 (which transitively requires SciMLBase v3) but Catalyst v16.1.1 still pins SciMLBase to v2. Catalyst#1463 widens that compat to include v3; once it lands and a Catalyst patch release is tagged, this PR's CI will resolve. Without `force_latest_compatible_version`, ordinary resolution falls back to OrdinaryDiffEqTsit5 v1 and tests pass today.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>