### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ ReactionNetworkImporters = {path = "../.."}
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,24 @@
-using ReactionNetworkImporters, Aqua
-using Test
-@testset "Aqua" begin
-    Aqua.find_persistent_tasks_deps(ReactionNetworkImporters)
-    Aqua.test_ambiguities(ReactionNetworkImporters, recursive = false)
-    Aqua.test_deps_compat(ReactionNetworkImporters)
-    Aqua.test_piracies(ReactionNetworkImporters)
-    Aqua.test_project_extras(ReactionNetworkImporters)
-    Aqua.test_stale_deps(ReactionNetworkImporters)
-    Aqua.test_unbound_args(ReactionNetworkImporters)
-    Aqua.test_undefined_exports(ReactionNetworkImporters)
-end
+using SciMLTesting, ReactionNetworkImporters, Test
+
+run_qa(
+    ReactionNetworkImporters;
+    explicit_imports = true,
+    ei_kwargs = (;
+        # `unwrap` is imported from `Symbolics` (its public, exported re-export) but
+        # its `Base.which` owner is `SymbolicUtils`, where it is non-public; allow the
+        # import from the public re-exporter.
+        all_explicit_imports_via_owners = (; ignore = (:unwrap,)),
+        all_explicit_imports_are_public = (; ignore = (:unwrap,)),
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :U0Map,        # public in Catalyst (declared `public`; only invisible to EI on Julia 1.10)
+                :ParameterMap, # public in Catalyst (declared `public`; only invisible to EI on Julia 1.10)
+                :parse,        # Base.Meta.parse, non-public stdlib name
+            ),
+        ),
+    ),
+    # Many names from the heavy DSL deps (Catalyst/Symbolics/SymbolicUtils/
+    # DataStructures/SparseArrays) are used implicitly via `using`; making them all
+    # explicit is a risky mass refactor. Tracked in SciML/ReactionNetworkImporters.jl#179.
+    ei_broken = (:no_implicit_imports,)
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -14,6 +14,7 @@ run_qa(
                 :U0Map,        # public in Catalyst (declared `public`; only invisible to EI on Julia 1.10)
                 :ParameterMap, # public in Catalyst (declared `public`; only invisible to EI on Julia 1.10)
                 :parse,        # Base.Meta.parse, non-public stdlib name
+                :eval,         # Base.eval, non-public Base name; required to eval BNG exprs in a target module
             ),
         ),
     ),


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Brings this repo's QA group onto the SciMLTesting `run_qa` v1.6 form with ExplicitImports enabled.

## Changes
- `test/qa/qa.jl`: hand-rolled `@testset "Aqua"` (eight Aqua sub-checks) -> `run_qa(ReactionNetworkImporters; explicit_imports = true, ...)`.
- `test/qa/Project.toml`: `SciMLTesting` compat `1` -> `1.6` (the v1.6 `run_qa` API: `explicit_imports`, `ei_kwargs`, `ei_broken`). `Aqua` kept as a direct dep (the `Aqua.test_ambiguities` child process needs it). ExplicitImports is **not** listed (transitive via SciMLTesting).

## Aqua
All eight previously hand-listed sub-checks run via `run_qa`/`Aqua.test_all` and pass. No `aqua_broken` and no preserved `aqua_kwargs` tweaks were needed (the original had none beyond `test_ambiguities(recursive = false)`, which the default run passes).

## ExplicitImports findings (6 checks, vs released SciMLTesting 1.6.0)
| Check | Result |
|---|---|
| `no_implicit_imports` | **`ei_broken`** — many implicit names from heavy DSL deps (Catalyst / Symbolics / SymbolicUtils / DataStructures / SparseArrays). Mass explicit-import refactor deferred; tracked in #179. Auto-flags once fixed. |
| `no_stale_explicit_imports` | pass |
| `all_explicit_imports_via_owners` | pass — ignore `unwrap` (imported from `Symbolics`, the public exported re-export; `Base.which` owner is `SymbolicUtils` where it is non-public). |
| `all_qualified_accesses_via_owners` | pass |
| `all_qualified_accesses_are_public` | pass — ignore `U0Map` / `ParameterMap` (declared `public` in Catalyst; only invisible to EI on Julia 1.10) and `parse` (`Base.Meta.parse`, non-public stdlib). |
| `all_explicit_imports_are_public` | pass — ignore `unwrap` (public in `Symbolics`, its re-exporter). |

No source code was changed: every finding was resolved by FIX-via-ignore (re-export / Julia-1.10 publicity artifacts / stdlib) or, for `no_implicit_imports`, an issue-tracked `@test_broken`.

## Local verification (released SciMLTesting 1.6.0, no dev-from-branch)
```
GROUP=QA, Julia 1.10 (lts):  Quality Assurance | 16 pass, 1 broken, 0 fail, 0 error
GROUP=QA, Julia 1.11 ("1"):   Quality Assurance | 16 pass, 1 broken, 0 fail, 0 error
```
Per-check (1.10): `no_implicit_imports` broken; the other five EI checks pass; all eight Aqua sub-checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)