### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReactionNetworkImporters"
 uuid = "b4db0fb7-de2a-5028-82bf-5021f5cfa881"
 authors = ["Samuel Isaacson <isaacsas@users.noreply.github.com>"]
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Automated patch version bump (1.3.1 -> 1.3.2) to release unreleased commits on `master` via JuliaRegistrator.