### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReactionNetworkImporters"
 uuid = "b4db0fb7-de2a-5028-82bf-5021f5cfa881"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Samuel Isaacson <isaacsas@users.noreply.github.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `master` can be registered in the General registry.

- ReactionNetworkImporters: 1.4.0 -> 1.5.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
