### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "Catalyst,OrdinaryDiffEqTsit5"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,37 @@
+using ReactionNetworkImporters, BenchmarkTools
+using Catalyst, OrdinaryDiffEqTsit5
+
+const SUITE = BenchmarkGroup()
+
+datadir = joinpath(@__DIR__, "..", "data")
+
+# =============================================================================
+# Network file loading (BioNetGen .net → ReactionSystem)
+# =============================================================================
+
+SUITE["load"] = BenchmarkGroup()
+
+SUITE["load"]["birth_death"] = @benchmarkable loadrxnetwork(
+    BNGNetwork(), joinpath($datadir, "nullrxs", "birth-death.net")
+)
+SUITE["load"]["repressilator"] = @benchmarkable loadrxnetwork(
+    BNGNetwork(), joinpath($datadir, "repressilator", "Repressilator.net")
+)
+SUITE["load"]["matrix_network"] = @benchmarkable loadrxnetwork(
+    MatrixNetwork([1.0], reshape([1], 1, 1), reshape([0], 1, 1));
+    name = :bench_matrix
+)
+
+# =============================================================================
+# Problem generation from an imported network
+# =============================================================================
+
+rnbng = loadrxnetwork(BNGNetwork(), joinpath(datadir, "nullrxs", "birth-death.net"))
+rn = complete(rnbng)
+
+SUITE["problem"] = BenchmarkGroup()
+
+SUITE["problem"]["ode_problem"] = @benchmarkable ODEProblem(
+    $rn, Float64[], (0.0, 10.0), Float64[]
+)
+SUITE["problem"]["complete"] = @benchmarkable complete($rnbng)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~85s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~85s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md